### PR TITLE
Make package more cohesive: Step 1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "0b638eaaea9f2faed40a976c1a71a9d2",
@@ -9,32 +9,34 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -54,12 +56,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -229,32 +231,37 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -284,35 +291,39 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/007c053ae6f31bba39dfa19a7726f56e9763bbea",
+                "reference": "007c053ae6f31bba39dfa19a7726f56e9763bbea",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -335,27 +346,27 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2019-08-09T12:45:53+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -364,10 +375,110 @@
                 }
             },
             "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -389,33 +500,39 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "^1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -434,41 +551,40 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
+            "time": "2019-09-12T14:27:41+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -481,26 +597,27 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
                 "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -515,8 +632,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -544,44 +661,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-10-03T11:07:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -596,7 +713,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -607,29 +724,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -644,7 +764,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -654,7 +774,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -699,28 +819,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -735,7 +855,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -744,33 +864,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -793,55 +913,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "7.5.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "316afa6888d2562e04aeb67ea7f2017a0eb41661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/316afa6888d2562e04aeb67ea7f2017a0eb41661",
+                "reference": "316afa6888d2562e04aeb67ea7f2017a0eb41661",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -849,7 +971,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -875,66 +997,56 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
+            "time": "2019-09-14T09:08:39+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "name": "psr/container",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
             "keywords": [
-                "mock",
-                "xunit"
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
             ],
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -987,32 +1099,31 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "1.1.0",
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
-                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
+                "files": [
+                    "src/getallheaders.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1020,18 +1131,12 @@
             ],
             "authors": [
                 {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
                 }
             ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2018-11-20T15:27:04+00:00"
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1080,30 +1185,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1134,38 +1239,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1190,34 +1296,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1242,34 +1354,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1283,6 +1395,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1291,16 +1407,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -1309,27 +1421,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1337,7 +1449,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1360,33 +1472,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1406,32 +1519,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1459,29 +1617,29 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1501,7 +1659,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1548,16 +1706,16 @@
         },
         {
             "name": "statonlab/tripal-test-suite",
-            "version": "1.5.1",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tripal/TripalTestSuite.git",
-                "reference": "c652f62c0e8302e00cf25a39c95a605b0266656f"
+                "reference": "3e877af0204c59b9aa6b7ef0324ca4b985a7e3b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tripal/TripalTestSuite/zipball/c652f62c0e8302e00cf25a39c95a605b0266656f",
-                "reference": "c652f62c0e8302e00cf25a39c95a605b0266656f",
+                "url": "https://api.github.com/repos/tripal/TripalTestSuite/zipball/3e877af0204c59b9aa6b7ef0324ca4b985a7e3b4",
+                "reference": "3e877af0204c59b9aa6b7ef0324ca4b985a7e3b4",
                 "shasum": ""
             },
             "require": {
@@ -1592,41 +1750,47 @@
                     "email": "bcondon@utk.edu"
                 }
             ],
-            "time": "2018-09-25T19:08:14+00:00"
+            "time": "2019-04-09T18:52:51+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.19",
+            "version": "v4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb"
+                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb",
-                "reference": "8f80fc39bbc3b7c47ee54ba7aa2653521ace94bb",
+                "url": "https://api.github.com/repos/symfony/console/zipball/de63799239b3881b8a08f8481b22348f77ed7b36",
+                "reference": "de63799239b3881b8a08f8481b22348f77ed7b36",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/service-contracts": "^1.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3",
                 "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3|~4.0",
+                "symfony/config": "~3.4|~4.0",
                 "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.3|~4.0"
+                "symfony/process": "~3.4|~4.0",
+                "symfony/var-dumper": "^4.3"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -1634,7 +1798,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.3-dev"
                 }
             },
             "autoload": {
@@ -1661,76 +1825,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T12:48:07+00:00"
-        },
-        {
-            "name": "symfony/debug",
-            "version": "v3.4.19",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "2016b3eec2e49c127dd02d0ef44a35c53181560d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/2016b3eec2e49c127dd02d0ef44a35c53181560d",
-                "reference": "2016b3eec2e49c127dd02d0ef44a35c53181560d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0|~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "time": "2019-08-26T08:26:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -1742,7 +1850,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1759,12 +1867,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1775,20 +1883,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
                 "shasum": ""
             },
             "require": {
@@ -1800,7 +1908,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1834,47 +1942,40 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.4.19",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "291e13d808bec481eab83f301f7bff3e699ef603"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/291e13d808bec481eab83f301f7bff3e699ef603",
-                "reference": "291e13d808bec481eab83f301f7bff3e699ef603",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/2ceb49eaccb9352bff54d22570276bb75ba4a188",
+                "reference": "2ceb49eaccb9352bff54d22570276bb75ba4a188",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "php": ">=5.3.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
+                    "Symfony\\Polyfill\\Php73\\": ""
                 },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1883,38 +1984,142 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:48:54+00:00"
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.3.0",
+            "name": "symfony/service-contracts",
+            "version": "v1.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1.3",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2019-08-20T14:44:19+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
             "extra": {
@@ -1943,7 +2148,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2019-08-24T08:43:50+00:00"
         }
     ],
     "aliases": [],

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -409,7 +409,7 @@ function tripal_jbrowse_mgmt_build_http_query($instance) {
   }
   // Otherwise, show all tracks that were added using this module.
   elseif (!empty($added_tracks)) {
-    $tracks_path = implode(',', array_map(function ($added_tracks) {
+    $tracks_path = implode(',', array_map(function ($track) {
       return tripal_jbrowse_mgmt_make_slug($track->label);
     }, $added_tracks));
   }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -397,18 +397,33 @@ function tripal_jbrowse_mgmt_copy_file($source, $destination) {
  */
 function tripal_jbrowse_mgmt_build_http_query($instance) {
   $path = tripal_jbrowse_mgmt_make_slug($instance->title);
-  $tracks = tripal_jbrowse_mgmt_get_tracks($instance);
+  $added_tracks = tripal_jbrowse_mgmt_get_tracks($instance);
+  $properties = tripal_jbrowse_mgmt_get_instance_properties($instance->id);
+
+  // Determine the tracks to display.
   $tracks_path = '';
-  if (!empty($tracks)) {
-    $tracks_path = implode(',', array_map(function ($track) {
+  // If the start-tracks property is set then use that directly.
+  if (isset($properties['start-tracks'])) {
+    $tracks_path = $properties['start-tracks'];
+  }
+  // Otherwise, show all tracks that were added using this module.
+  elseif (!empty($added_tracks)) {
+    $tracks_path = implode(',', array_map(function ($added_tracks) {
       return tripal_jbrowse_mgmt_make_slug($track->label);
-    }, $tracks));
+    }, $added_tracks));
   }
 
-  return [
+  $query_params = [
     'data' => "data/$path/data",
     'tracks' => $tracks_path,
   ];
+
+  // Now we need to add start location if it's set.
+  if (isset($properties['start-loc'])) {
+    $query_params['loc'] = $properties['start-loc'];
+  }
+
+  return $query_params;
 }
 
 /**
@@ -604,4 +619,20 @@ function tripal_jbrowse_mgmt_get_instance_property($id, $type) {
     ->condition('instance_id', $id)
     ->condition('property_type', $type)
     ->execute()->fetchField();
+}
+
+/**
+ * Retrieves all properties for a given instance.
+ *
+ * @param $id
+ *   The instance ID.
+ * @return
+ *   An array of properties for the specified instance
+ *   where the key: property type and value: property value.
+ */
+function tripal_jbrowse_mgmt_get_instance_properties($id) {
+  return db_select('tripal_jbrowse_mgmt_instanceprop', 'p')
+    ->fields('p', ['property_type', 'value'])
+    ->condition('instance_id', $id)
+    ->execute()->fetchAllKeyed(0,1);
 }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -529,3 +529,79 @@ function tripal_jbrowse_mgmt_get_track_types() {
     'XYPlot',
   ];
 }
+
+/**
+ * Save properties for a given instance.
+ *
+ * @param $id
+ *   The instance ID that properties should be associated with.
+ * @param $data
+ *   An array of properties where each is
+ *   key: property_type, value: property value.
+ */
+function tripal_jbrowse_mgmt_save_instance_properties($id, $data) {
+
+  // For each property...
+  foreach ($data as $type => $value) {
+    tripal_jbrowse_mgmt_save_instance_property($id, $type, $value);
+  }
+
+}
+
+/**
+ * Save the details for a specific property of a given instance.
+ *
+ * @param $id
+ *   The instance ID that properties should be associated with.
+ * @param $type
+ *   The name of the property type to be saved.
+ * @param $value
+ *   The value of the property to be saved.
+ */
+function tripal_jbrowse_mgmt_save_instance_property($id, $type, $value) {
+
+  // Check to see if the property already exists.
+  $result = db_select('tripal_jbrowse_mgmt_instanceprop', 'p')
+    ->fields('p', ['value'])
+    ->condition('instance_id', $id)
+    ->condition('property_type', $type)
+    ->execute()->fetchObject();
+
+  // If the property doesn't already exist then insert it.
+  if (empty($result)) {
+    return db_insert('tripal_jbrowse_mgmt_instanceprop')
+      ->fields([
+        'instance_id' => $id,
+        'property_type' => $type,
+        'value' => $value,
+      ])->execute();
+  }
+  // Otherwise, we need to update it.
+  else {
+    return db_update('tripal_jbrowse_mgmt_instanceprop')
+      ->fields([
+        'value' => $value,
+      ])
+      ->condition('instance_id', $id)
+      ->condition('property_type', $type)
+      ->execute();
+  }
+}
+
+/**
+ * Retrieves the value for a given instance property.
+ *
+ * @param $id
+ *   The instance ID.
+ * @param $type
+ *   The name of the property type.
+ * @return
+ *   The value of the property for a given instance.
+ */
+function tripal_jbrowse_mgmt_get_instance_property($id, $type) {
+  return db_select('tripal_jbrowse_mgmt_instanceprop', 'p')
+    ->fields('p', ['value'])
+    ->condition('instance_id', $id)
+    ->condition('property_type', $type)
+    ->execute()->fetchField();
+}

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -97,6 +97,58 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     '#disabled' => ($edit_form) ? TRUE : FALSE,
   ];
 
+  $form['page'] = [
+    '#type' => 'fieldset',
+    '#tree' => TRUE,
+    '#title' => 'Instance Page Settings',
+    '#description' => 'The following settings pertain to link directing users to this instance (either embedded or the original).',
+  ];
+
+  $form['page']['start_loc'] = [
+    '#type' => 'textfield',
+    '#title' => 'Start Location',
+    '#description' => "<p>The initial genomic position which will be visible in
+      the viewing field. Possible input strings are:</p>\r\n
+    <strong>\"Chromosome\": \"start point\"..\"end point\"</strong>\r\n<p>A
+      chromosome name/ID followed by “:”, starting position, “..” and end
+      position of the genome to be viewed in the browser is used as an input.
+      Chromosome ID can be either a string or a mix of string and numbers.
+      “CHR” to indicate chromosome may or may not be used. Strings are not
+      case-sensitive. If the chromosome ID is found in the database reference
+      sequence (RefSeq), the chromosome will be shown from the starting
+      position to the end position given in URL.</p>\r\n
+      <pre>     ctgA:100..200</pre>\r\n
+      <p>Chromosome ctgA will be displayed from position 100 to 200.</p>\r\n
+    OR <strong>start point\"..\"end point</strong>\r\n<p>A string of
+      numerical value, “..” and another numerical value is given with the loc
+      option. JBrowse navigates through the currently selected chromosome from
+      the first numerical value, start point, to the second numerical value,
+      end point.</p>\r\n<pre>     200..600</pre>\r\n<p>Displays position 200
+      to 600 of the current chromosome.</p>\r\n
+    OR <strong>center base</strong>\r\n<p>If only one numerical value is given
+      as an input, JBrowse treats the input as the center position. Then an
+      arbitrary region of the currently selected gene is displayed in the
+      viewing field with the given input position as basepair position on
+      which to center the view.</p>\r\n
+    OR <strong>feature name/ID</strong>\r\n<p>If a string or a mix of string
+      and numbers are entered as an input, JBrowse treats the input as a
+      feature name/ID of a gene. If the ID exists in the database RefSeq,
+      JBrowser displays an arbitrary region of the feature from the the
+      position 0, starting position of the gene, to a certain end point.</p>\r\n
+      <pre>     ctgA</pre>\r\n<p>Displays an arbitrary region from the ctgA
+      reference.</p>",
+  ];
+
+  $form['page']['start_tracks'] = [
+    '#type' => 'textarea',
+    '#rows' => 2,
+    '#title' => 'Tracks to Display',
+    '#description' => "<p>A comma-delimited strings containing track names,
+      each of which should correspond to the \"label\" element of the track
+      information dictionaries that are currently viewed in the viewing field.</p>\r\n
+      <pre>     DNA,knownGene,ccdsGene,snp131,pgWatson,simpleRepeat</pre>",
+  ];
+
   $button = 'Create New Instance';
   if ($edit_form) {
     $button = 'Save Changes';
@@ -204,14 +256,12 @@ function tripal_jbrowse_mgmt_add_form_submit($form, &$form_state) {
 
     $title = tripal_jbrowse_mgmt_construct_organism_name($organism);
 
-    $success = db_update('tripal_jbrowse_mgmt_instances')
-      ->fields([
-        'organism_id' => $organism_id,
-        'title' => $title,
-        'description' => $description,
-      ])
-      ->condition('id', $instance_id)
-      ->execute();
+    $data = [
+      'organism_id' => $organism_id,
+      'title' => $title,
+      'description' => $description,
+    ];
+    $success = tripal_jbrowse_mgmt_update_instance($instance_id, $data);
 
     if ($success) {
       drupal_set_message("Successfully updated $title JBrowse instance.");

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -3,13 +3,15 @@
 function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
   $settings = tripal_jbrowse_mgmt_get_settings();
 
-  if (empty(array_values($settings))) {
+  // Ensure the module is configured.
+  if (empty(array_filter($settings))) {
     $form['incomplete'] = [
       '#type' => 'item',
-      '#prefix' => '<div style="color: red;">',
+      '#prefix' => '<div class="messages error">',
       '#markup' => t(
-        'You have not configured the module yet. Please visit the 
-                      settings page and submit the form before continuing.'
+        'You have not configured the module yet. Please visit the
+            <a href="@url">settings page</a> and submit the form before continuing.',
+        ['@url' => url('admin/tripal/extension/tripal_jbrowse/management/configure')]
       ),
       '#suffix' => '</div>',
     ];
@@ -28,7 +30,7 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
   $form['description_of_form'] = [
     '#type' => 'item',
     '#markup' => t(
-      'Create a new JBrowse instance for a given organism. Submitting this form 
+      'Create a new JBrowse instance for a given organism. Submitting this form
       creates all the necessary files for a new JBrowse instance.'
     ),
   ];

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -311,7 +311,9 @@ function tripal_jbrowse_mgmt_add_form_submit($form, &$form_state) {
       );
       $form_state['redirect'] = "admin/tripal/extension/tripal_jbrowse/management/instances/$instance_id";
     }
-    drupal_set_message('Failed to create instance!', 'error');
+    else {
+      drupal_set_message('Failed to create instance!', 'error');
+    }
   }
 
   // Now save the instance properties.

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -19,6 +19,21 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     return $form;
   }
 
+  // Check to see if this is an edit form.
+  $edit_form = FALSE;
+  if (isset($form_state['build_info']['args'][0]) AND is_numeric($form_state['build_info']['args'][0])) {
+    $instance_id = $form_state['build_info']['args'][0];
+    $result = tripal_jbrowse_mgmt_get_instances(['id' => $instance_id]);
+    if (!empty($result)) {
+      $instance = $result[0];
+      $edit_form = TRUE;
+    }
+    else {
+      drupal_set_message('Unable to access the instance you would like to edit.', 'error');
+      return $form;
+    }
+  }
+
   $organisms = tripal_jbrowse_mgmt_get_organisms_list();
   $mapped_organisms = [];
   foreach ($organisms as $organism) {
@@ -27,12 +42,14 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     );
   }
 
+  $form_description = 'Create a new JBrowse instance for a given organism. Submitting this form
+  creates all the necessary files for a new JBrowse instance.';
+  if ($edit_form) {
+    $form_description = 'Edit details regarding the current JBrowse instance.';
+  }
   $form['description_of_form'] = [
     '#type' => 'item',
-    '#markup' => t(
-      'Create a new JBrowse instance for a given organism. Submitting this form
-      creates all the necessary files for a new JBrowse instance.'
-    ),
+    '#markup' => t($form_description),
   ];
 
   $form['organism'] = [
@@ -41,12 +58,14 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     '#type' => 'select',
     '#options' => $mapped_organisms,
     '#required' => TRUE,
+    '#default_value' => ($edit_form) ? $instance->organism_id : NULL,
   ];
 
   $form['description'] = [
     '#title' => t('Description'),
     '#description' => t('Optional description for the instance.'),
     '#type' => 'textarea',
+    '#default_value' => ($edit_form) ? $instance->description : NULL,
   ];
 
   $form['data'] = [
@@ -66,6 +85,7 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
   $form['data']['ref_seq_file'] = [
     '#type' => 'file',
     '#title' => t('Reference Sequence FASTA File'),
+    '#disabled' => ($edit_form) ? TRUE : FALSE,
   ];
 
   $form['data']['ref_seq_path'] = [
@@ -74,11 +94,16 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     '#description' => t(
       'This path will be ignored if a file is provided above. Ex: sites/default/files/file.fasta or /data/file.fasta'
     ),
+    '#disabled' => ($edit_form) ? TRUE : FALSE,
   ];
 
+  $button = 'Create New Instance';
+  if ($edit_form) {
+    $button = 'Save Changes';
+  }
   $form['submit'] = [
     '#type' => 'submit',
-    '#value' => 'Create New Instance',
+    '#value' => $button,
   ];
 
   return $form;
@@ -93,37 +118,49 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
 function tripal_jbrowse_mgmt_add_form_validate($form, &$form_state) {
   $values = $form_state['values'];
   $organism = isset($values['organism']) ? $values['organism'] : NULL;
-  $file = $_FILES['files']['tmp_name']['ref_seq_file'];
-  $local_file = isset($values['ref_seq_path']) ? $values['ref_seq_path'] : NULL;
 
-  if (empty($file) && empty($local_file)) {
-    form_set_error(
-      'ref_seq_file',
-      'Please provide a local file path or upload a new file.'
-    );
+  // Check if this is an add or edit form.
+  $edit_form = FALSE;
+  if (isset($form_state['build_info']['args'][0]) AND is_numeric($form_state['build_info']['args'][0])) {
+    $instance_id = $form_state['build_info']['args'][0];
+    $edit_form = TRUE;
   }
-  elseif (empty($file) && !empty($local_file)) {
-    if (!file_exists($local_file)) {
-      form_set_error('ref_seq_path', 'The file path provided does not exist.');
+
+  if (!$edit_form) {
+    $file = $_FILES['files']['tmp_name']['ref_seq_file'];
+    $local_file = isset($values['ref_seq_path']) ? $values['ref_seq_path'] : NULL;
+
+    if (empty($file) && empty($local_file)) {
+      form_set_error(
+        'ref_seq_file',
+        'Please provide a local file path or upload a new file.'
+      );
     }
-  }
-  else {
-    $uploaded = tripal_jbrowse_mgmt_upload_file('ref_seq_file');
-    if (!$uploaded) {
-      form_set_error('ref_seq_file', 'Unable to upload file');
+    elseif (empty($file) && !empty($local_file)) {
+      if (!file_exists($local_file)) {
+        form_set_error('ref_seq_path', 'The file path provided does not exist.');
+      }
     }
     else {
-      $uploaded = tripal_jbrowse_mgmt_move_file($uploaded);
-      $form_state['values']['uploaded_file'] = $uploaded;
+      $uploaded = tripal_jbrowse_mgmt_upload_file('ref_seq_file');
+      if (!$uploaded) {
+        form_set_error('ref_seq_file', 'Unable to upload file');
+      }
+      else {
+        $uploaded = tripal_jbrowse_mgmt_move_file($uploaded);
+        $form_state['values']['uploaded_file'] = $uploaded;
+      }
     }
   }
 
   $instances = tripal_jbrowse_mgmt_get_instances(['organism_id' => $organism]);
   if (!empty($instances)) {
-    form_set_error(
-      'organism',
-      'A JBrowse instance for the selected organism already exists. You can edit the instance from the instances page.'
-    );
+    if (!$edit_form OR ($edit_form AND $instances[0]->id != $instance_id)) {
+      form_set_error(
+        'organism',
+        'A JBrowse instance for the selected organism already exists. You can edit the instance from the instances page.'
+      );
+    }
   }
 
   $organism = db_select('chado.organism', 'CO')
@@ -150,44 +187,79 @@ function tripal_jbrowse_mgmt_add_form_submit($form, &$form_state) {
   $organism_id = $values['organism'];
   $description = isset($values['description']) ? $values['description'] : '';
 
-  if (empty($values['uploaded_file'])) {
-    $file = $values['ref_seq_path'];
+  // Check if this is an add or edit form.
+  $edit_form = FALSE;
+  if (isset($form_state['build_info']['args'][0]) AND is_numeric($form_state['build_info']['args'][0])) {
+    $instance_id = $form_state['build_info']['args'][0];
+    $edit_form = TRUE;
+  }
+
+  if ($edit_form) {
+
+    $organism = db_select('chado.organism', 'CO')
+      ->fields('CO')
+      ->condition('organism_id', $organism_id)
+      ->execute()
+      ->fetchObject();
+
+    $title = tripal_jbrowse_mgmt_construct_organism_name($organism);
+
+    $success = db_update('tripal_jbrowse_mgmt_instances')
+      ->fields([
+        'organism_id' => $organism_id,
+        'title' => $title,
+        'description' => $description,
+      ])
+      ->condition('id', $instance_id)
+      ->execute();
+
+    if ($success) {
+      drupal_set_message("Successfully updated $title JBrowse instance.");
+      $form_state['redirect'] = 'admin/tripal/extension/tripal_jbrowse/management/instances';
+    }
+    else {
+      drupal_set_message('Failed to update the current instance!', 'error');
+    }
   }
   else {
-    $file = $values['uploaded_file'];
-  }
+    if (empty($values['uploaded_file'])) {
+      $file = $values['ref_seq_path'];
+    }
+    else {
+      $file = $values['uploaded_file'];
+    }
 
-  $organism = db_select('chado.organism', 'CO')
-    ->fields('CO')
-    ->condition('organism_id', $organism_id)
-    ->execute()
-    ->fetchObject();
+    $organism = db_select('chado.organism', 'CO')
+      ->fields('CO')
+      ->condition('organism_id', $organism_id)
+      ->execute()
+      ->fetchObject();
 
-  $instance_id = tripal_jbrowse_mgmt_create_instance(
-    [
-      'organism_id' => $organism_id,
-      'title' => tripal_jbrowse_mgmt_construct_organism_name($organism),
-      'description' => $description,
-      'created_at' => time(),
-      'file' => $file,
-    ]
-  );
-
-  if ($instance_id) {
-    drupal_set_message('Instance created successfully!');
-    $name = 'Create JBrowse instance for ';
-    $name .= tripal_jbrowse_mgmt_construct_organism_name($organism);
-
-    tripal_add_job(
-      $name,
-      'tripal_jbrowse_mgmt',
-      'tripal_jbrowse_mgmt_create_instance_files',
-      [$instance_id],
-      $user->uid
+    $instance_id = tripal_jbrowse_mgmt_create_instance(
+      [
+        'organism_id' => $organism_id,
+        'title' => tripal_jbrowse_mgmt_construct_organism_name($organism),
+        'description' => $description,
+        'created_at' => time(),
+        'file' => $file,
+      ]
     );
-    drupal_goto("admin/tripal/extension/tripal_jbrowse/management/instances/$instance_id");
-    return $form;
-  }
 
-  drupal_set_message('Failed to create instance!');
+    if ($instance_id) {
+      drupal_set_message('Instance created successfully!');
+      $name = 'Create JBrowse instance for ';
+      $name .= tripal_jbrowse_mgmt_construct_organism_name($organism);
+
+      tripal_add_job(
+        $name,
+        'tripal_jbrowse_mgmt',
+        'tripal_jbrowse_mgmt_create_instance_files',
+        [$instance_id],
+        $user->uid
+      );
+      $form_state['redirect'] = "admin/tripal/extension/tripal_jbrowse/management/instances/$instance_id";
+      return $form;
+    }
+    drupal_set_message('Failed to create instance!', 'error');
+  }
 }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -104,7 +104,7 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     '#description' => 'The following settings pertain to link directing users to this instance (either embedded or the original).',
   ];
 
-  $form['page']['start_loc'] = [
+  $form['page']['start-loc'] = [
     '#type' => 'textfield',
     '#title' => 'Start Location',
     '#description' => "<p>The initial genomic position which will be visible in
@@ -137,9 +137,10 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
       position 0, starting position of the gene, to a certain end point.</p>\r\n
       <pre>     ctgA</pre>\r\n<p>Displays an arbitrary region from the ctgA
       reference.</p>",
+    '#default_value' => ($edit_form) ? tripal_jbrowse_mgmt_get_instance_property($instance_id, 'start-loc') : NULL,
   ];
 
-  $form['page']['start_tracks'] = [
+  $form['page']['start-tracks'] = [
     '#type' => 'textarea',
     '#rows' => 2,
     '#title' => 'Tracks to Display',
@@ -147,6 +148,7 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
       each of which should correspond to the \"label\" element of the track
       information dictionaries that are currently viewed in the viewing field.</p>\r\n
       <pre>     DNA,knownGene,ccdsGene,snp131,pgWatson,simpleRepeat</pre>",
+    '#default_value' => ($edit_form) ? tripal_jbrowse_mgmt_get_instance_property($instance_id, 'start-tracks') : NULL,
   ];
 
   $button = 'Create New Instance';
@@ -308,8 +310,13 @@ function tripal_jbrowse_mgmt_add_form_submit($form, &$form_state) {
         $user->uid
       );
       $form_state['redirect'] = "admin/tripal/extension/tripal_jbrowse/management/instances/$instance_id";
-      return $form;
     }
     drupal_set_message('Failed to create instance!', 'error');
   }
+
+  // Now save the instance properties.
+  tripal_jbrowse_mgmt_save_instance_properties(
+    $instance_id,
+    $form_state['values']['page']
+  );
 }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_configure.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_configure.form.inc
@@ -8,13 +8,13 @@
  * @return mixed
  */
 function tripal_jbrowse_mgmt_configure_form($form, &$form_state) {
+
+  $message = '<p>Before filling out this form, ensure you have downloaded and installed JBrowse on your server. At this time, JBrowse needs to be on the same server as this Tripal site. <br /><strong>This form allows you to configure the location of JBrowse.</strong></p>';
+
   $form['message'] = [
     '#type' => 'markup',
     '#prefix' => '<p>',
-    '#markup' => t(
-      'This form allows administrators to control 
-      where JBrowse lives on the server.'
-    ),
+    '#markup' => t($message),
     '#suffix' => '</p>',
   ];
 
@@ -23,7 +23,7 @@ function tripal_jbrowse_mgmt_configure_form($form, &$form_state) {
   $form['data_dir'] = [
     '#title' => t('Data Directory'),
     '#description' => t(
-      'Absolute path to where data directories should live. 
+      'Absolute path to where data directories should live.
        This directory must be accessible by the apache user.'
     ),
     '#type' => 'textfield',
@@ -59,7 +59,7 @@ function tripal_jbrowse_mgmt_configure_form($form, &$form_state) {
   $form['menu_template'] = [
     '#title' => t('Default menuTemplate'),
     '#description' => t(
-      'Default menuTemplate in the trackList.json file. See 
+      'Default menuTemplate in the trackList.json file. See
        the JBrowse documentation for more info.'
     ),
     '#type' => 'textarea',

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_instance.page.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_instance.page.inc
@@ -18,6 +18,14 @@ function tripal_jbrowse_mgmt_instance_page($instance_id) {
 
   drupal_set_title("Manage $instance->title JBrowse");
 
+  $breadcrumb = array();
+  $breadcrumb[] = l('Home', '');
+  $breadcrumb[] = l('Administration', 'admin');
+  $breadcrumb[] = l('Tripal', 'admin/tripal');
+  $breadcrumb[] = l('Extensions', 'admin/tripal/extension');
+  $breadcrumb[] = l('Tripal JBrowse', 'admin/tripal/extension/tripal_jbrowse/management');
+  drupal_set_breadcrumb($breadcrumb);
+
   $content = [];
 
   $content['instance_table'] = [

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_json_editor.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_json_editor.form.inc
@@ -19,6 +19,15 @@ function tripal_jbrowse_mgmt_json_editor_form($form, &$form_state, $track_id) {
 
   drupal_set_title('Edit Track: ' . $track->label);
 
+  $breadcrumb = array();
+  $breadcrumb[] = l('Home', '');
+  $breadcrumb[] = l('Administration', 'admin');
+  $breadcrumb[] = l('Tripal', 'admin/tripal');
+  $breadcrumb[] = l('Extensions', 'admin/tripal/extension');
+  $breadcrumb[] = l('Tripal JBrowse', 'admin/tripal/extension/tripal_jbrowse/management');
+  $breadcrumb[] = l('Instance', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$track->instance_id);
+  drupal_set_breadcrumb($breadcrumb);
+
   $instance = tripal_jbrowse_mgmt_get_instance($track->instance_id);
   $json = tripal_jbrowse_mgmt_get_json($instance);
   $form_state['track_json'] = $json;

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
@@ -8,6 +8,14 @@ function tripal_jbrowse_mgmt_instances_page() {
   $instances = tripal_jbrowse_mgmt_get_instances();
   $settings = tripal_jbrowse_mgmt_get_settings();
 
+  // Ensure people set settings before adding an instance!
+  if (empty($settings['data_dir'])) {
+    drupal_set_message(t(
+      'The <a href="@url">Location of your JBrowse</a> is required before creating an instance.',
+        ['@url' => url('admin/tripal/extension/tripal_jbrowse/management/configure')]),
+      'error');
+  }
+
   $content = [];
 
   if (empty($instances)) {

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
@@ -49,7 +49,10 @@ function tripal_jbrowse_mgmt_instances_page() {
       l(
         'Launch',
         $settings['link'],
-        ['query' => tripal_jbrowse_mgmt_build_http_query($instance)]
+        [
+          'query' => tripal_jbrowse_mgmt_build_http_query($instance),
+          'attributes' => ['target' => '_blank'],
+        ]
       ),
       l('Edit', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$instance->id.'/edit') . ' <br /> ' .
       l('Delete', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$instance->id.'/delete'),

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
@@ -31,9 +31,9 @@ function tripal_jbrowse_mgmt_instances_page() {
     'Organism',
     'Submitter',
     'Description',
-    'Manage',
+    'Tracks',
     'Launch',
-    'Delete',
+    'Instance',
   ];
 
   $rows = [];
@@ -51,7 +51,8 @@ function tripal_jbrowse_mgmt_instances_page() {
         $settings['link'],
         ['query' => tripal_jbrowse_mgmt_build_http_query($instance)]
       ),
-      l('Delete Instance', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$instance->id.'/delete'),
+      l('Edit', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$instance->id.'/edit') . ' <br /> ' .
+      l('Delete', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$instance->id.'/delete'),
 
     ];
   }

--- a/tripal_jbrowse_mgmt/tripal_jbrowse_mgmt.install
+++ b/tripal_jbrowse_mgmt/tripal_jbrowse_mgmt.install
@@ -98,5 +98,33 @@ function tripal_jbrowse_mgmt_schema() {
     ],
   ];
 
+  $schema['tripal_jbrowse_mgmt_instanceprop'] = [
+    'description' => 'JBrowse Instance Metadata.',
+    'fields' => [
+      'instance_id' => [
+        'type' => 'int',
+        'not null' => TRUE,
+      ],
+      'property_type' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+      ],
+      'value' => [
+        'type' => 'text',
+      ],
+    ]
+  ];
+
   return $schema;
+}
+
+/**
+ * Create instance metadata table.
+ */
+function tripal_jbrowse_mgmt_update_7001(&$sandbox) {
+  $schema = tripal_jbrowse_mgmt_schema();
+  $name = "tripal_jbrowse_mgmt_instanceprop";
+  $table = $schema[$name];
+  db_create_table($name, $table);
 }

--- a/tripal_jbrowse_mgmt/tripal_jbrowse_mgmt.module
+++ b/tripal_jbrowse_mgmt/tripal_jbrowse_mgmt.module
@@ -26,6 +26,16 @@ function tripal_jbrowse_mgmt_menu() {
     'type' => MENU_NORMAL_ITEM,
   ];
 
+  $items['admin/tripal/extension/tripal_jbrowse/management/instances'] = [
+    'title' => 'List Instances',
+    'description' => 'List JBrowse settings',
+    'page callback' => 'tripal_jbrowse_mgmt_instances_page',
+    'page arguments' => ['tripal_jbrowse_mgmt_configure_form'],
+    'access arguments' => ['administer tripal_jbrowse_mgmt'],
+    'file' => 'includes/tripal_jbrowse_mgmt_list.page.inc',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+  ];
+
   $items['admin/tripal/extension/tripal_jbrowse/management/configure'] = [
     'title' => 'Settings',
     'description' => 'List and create JBrowse instances.',

--- a/tripal_jbrowse_mgmt/tripal_jbrowse_mgmt.module
+++ b/tripal_jbrowse_mgmt/tripal_jbrowse_mgmt.module
@@ -66,8 +66,18 @@ function tripal_jbrowse_mgmt_menu() {
     'type' => MENU_CALLBACK,
   ];
 
+  $items['admin/tripal/extension/tripal_jbrowse/management/instances/%/edit'] = [
+    'title' => 'Edit Instance',
+    'description' => 'Edit metadata for existing JBrowse instances.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['tripal_jbrowse_mgmt_add_form', 6],
+    'access arguments' => ['administer tripal_jbrowse_mgmt'],
+    'file' => 'includes/tripal_jbrowse_mgmt_add.form.inc',
+    'type' => MENU_LOCAL_ACTION,
+  ];
+
   $items['admin/tripal/extension/tripal_jbrowse/management/instances/%/delete'] = [
-    'title' => 'Delete an instance',
+    'title' => 'Delete Instance',
     'description' => 'Confirm deleting an instance.',
     'page callback' => 'drupal_get_form',
     'page arguments' => ['tripal_jbrowse_mgmt_delete_instance_form', 6],


### PR DESCRIPTION
Issue #25 

This PR 
1. Extends "Tripal JBrowse Management" to keep track of start location and initial tracks to display. 
2. Adds edit functionality for JBrowse instances created by "Tripal JBrowse Management"
3. Fixes some minor bugs: ensure module is configured, settings tab shows up, breadcrumbs are accurate.

Testing
1. Check that existing JBrowse instance functionality is not altered (launch link is unchanged)
2. Check that you can edit existing JBrowse instances with or without entering start location and tracks
3. Check you can create a new JBrowse instance with or withour entering start location and tracks.