### PR TITLE
Updated documentation and assumption fix

### DIFF
--- a/docs/guide/install/dependencies.rst
+++ b/docs/guide/install/dependencies.rst
@@ -1,7 +1,11 @@
-Dependencies
-============
+1) Dependencies
+=================
 
 Please ensure that the following are installed on your server:
 
 - `JBrowse <http://gmod.org/wiki/JBrowse_Configuration_Guide>`_.
 - `Tripal <http://tripal.info>`_
+
+.. note::
+
+  JBrowse must be unpacked and ``./setup.sh`` run. It must be located in a directory accessible by your webserver. We recommend ``[drupalsite]/tools/jbrowse``.

--- a/docs/guide/install/instance_page.rst
+++ b/docs/guide/install/instance_page.rst
@@ -1,38 +1,14 @@
-JBrowse Page Integration
-========================
+3) Tripal JBrowse Page Integration
+=====================================
 
-This guide will show you **how to create a page within your Tripal site for an existing JBrowse instance**. This ensures a *consistent user experience* by making the menu system of the Tripal site available to the user while browsing. If the user needs more space they can choose the *FullScreen option* to remove the menus.
+This module is available for download from github.com/tripal/tripal_jbrowse.
 
-.. warning::
+1. Download and upack the module into ``[DRUPAL ROOT]/sites/all/modules`` where ``DRUPAL_ROOT`` is the path to your Drupal site.
+2. Navigate to ``https://yourdrupalsite.com/admin/modules`` or click **Administration Toolbar > Modules**
+3. Scroll to **Tripal Extensions**, click the checkbox beside "Tripal JBrowse Integration", and click the "Save Configuration" button at the bottom of the page.
 
-   This requires you already have a JBrowse instance. Both local (hosted on the same machine as your Tripal site) or external JBrowse instances are supported.
-
-.. note::
-
-   The Tripal JBrowse Management sub-module provides a user interface to ease setup of multiple JBrowse instances. It is a great option but is not required.
-
-You create a JBrowse Instance page by navigating to **Content > Add Content > JBrowse Instance** on the Administration Toolbar. Then just fill out the form and click save!
-
-.. image:: ../../assets/instancepage.1.addcontent.png
-
-.. image:: ../../assets/instancepage.2.addinstance.png
-
-The **title** will become the title of the page and the **description** will be shown above the JBrowse instances. The description is a good place to add any warnings or instructions.
-
-.. image:: ../../assets/instancepage.3.createtop.png
-
-The **Existing JBrowse URL** is the URL to the JBrowse instance you want to embed. You should be able to put this URL into your browser and access the JBrowse instance directly, even in the case of local instances.
-
-The **Start Locations** allows you to specify where you want the JBrowse to navigate to for first time users. Keep in mind that JBrowse caches user location and thus all subsequent times a user accesses the instance it will start at their last browsed location.
-
-.. image:: ../../assets/instancepage.4.createbottom.png
-
-The **Tracks** allows you to set which tracks you want shown by default. You should enter the machine name of the tracks here with multiple tracks separated by comma's.
+.. image:: ../../assets/tripal_jbrowse.1.install.png
 
 .. note::
 
-    Depending on how your Drupal site is configured, you may be presented with a **Preview** button instead of a **Save** button. In this case, simply click Preview and then on the next page, click Save.
-
-    The preview for the JBrowse may not load properly. Do not be concerned as this is not an indication that you have incorrectly configured the page.
-
-    To disable the preview button, navigate to Structure > Content Types > JBrowse Instance > edit and set the "Submission for settings" > "Preview before submitting" to "Disabled".
+   This module is dependent upon the **Link** module. It is not mentioned above in the install instructions since you should already have installed it when installing Tripal.

--- a/docs/guide/install/jbrowse_mgmt.rst
+++ b/docs/guide/install/jbrowse_mgmt.rst
@@ -1,5 +1,5 @@
-Tripal JBrowse Management
-=========================
+2) Tripal JBrowse Management
+==============================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/guide/install/jbrowse_mgmt/configuration.rst
+++ b/docs/guide/install/jbrowse_mgmt/configuration.rst
@@ -1,5 +1,5 @@
-Tripal JBrowse Configuration
-==============================
+Configuration
+===============
 
 In order for the module to function properly, you need to first configure it.
 Please visit ``http://YOUR_SITE/admin/tripal_jbrowse/configure`` (replace YOUR_SITE with your domain)

--- a/docs/guide/install/jbrowse_mgmt/install.rst
+++ b/docs/guide/install/jbrowse_mgmt/install.rst
@@ -1,14 +1,10 @@
-Tripal JBrowse Installation
-============================
+Installation
+==============
 
-This module is available for download from github.com/tripal/tripal_jbrowse.
-
-1. Download and upack the module into ``[DRUPAL ROOT]/sites/all/modules`` where ``DRUPAL_ROOT`` is the path to your Drupal site.
-2. Navigate to ``https://yourdrupalsite.com/admin/modules`` or click **Administration Toolbar > Modules**
-3. Scroll to **Tripal Extensions**, click the checkbox beside "Tripal JBrowse Integration", and click the "Save Configuration" button at the bottom of the page.
-
-.. image:: ../../../assets/tripal_jbrowse.1.install.png
+1. Download the module to your Drupal modules folder
+2. Run drush en -y hardwoods_jbrowse or enable through the modules page
+3. Visit the configuration page at /admin/hardwoods_jbrowse/configure
 
 .. note::
 
-   This module is dependent upon the **Link** module. It is not mentioned above in the install instructions since you should already have installed it when installing Tripal.
+  JBrowse must be unpacked and ``./setup.sh`` run. It must be located in a directory accessible by your webserver. We recommend ``[drupalsite]/tools/jbrowse``.

--- a/docs/guide/instance_page.rst
+++ b/docs/guide/instance_page.rst
@@ -1,0 +1,38 @@
+JBrowse Page Integration
+========================
+
+This guide will show you **how to create a page within your Tripal site for an existing JBrowse instance**. This ensures a *consistent user experience* by making the menu system of the Tripal site available to the user while browsing. If the user needs more space they can choose the *FullScreen option* to remove the menus.
+
+.. warning::
+
+   This requires you already have a JBrowse instance. Both local (hosted on the same machine as your Tripal site) or external JBrowse instances are supported.
+
+.. note::
+
+   The Tripal JBrowse Management sub-module provides a user interface to ease setup of multiple JBrowse instances. It is a great option but is not required.
+
+You create a JBrowse Instance page by navigating to **Content > Add Content > JBrowse Instance** on the Administration Toolbar. Then just fill out the form and click save!
+
+.. image:: ../assets/instancepage.1.addcontent.png
+
+.. image:: ../assets/instancepage.2.addinstance.png
+
+The **title** will become the title of the page and the **description** will be shown above the JBrowse instances. The description is a good place to add any warnings or instructions.
+
+.. image:: ../assets/instancepage.3.createtop.png
+
+The **Existing JBrowse URL** is the URL to the JBrowse instance you want to embed. You should be able to put this URL into your browser and access the JBrowse instance directly, even in the case of local instances.
+
+The **Start Locations** allows you to specify where you want the JBrowse to navigate to for first time users. Keep in mind that JBrowse caches user location and thus all subsequent times a user accesses the instance it will start at their last browsed location.
+
+.. image:: ../assets/instancepage.4.createbottom.png
+
+The **Tracks** allows you to set which tracks you want shown by default. You should enter the machine name of the tracks here with multiple tracks separated by comma's.
+
+.. note::
+
+    Depending on how your Drupal site is configured, you may be presented with a **Preview** button instead of a **Save** button. In this case, simply click Preview and then on the next page, click Save.
+
+    The preview for the JBrowse may not load properly. Do not be concerned as this is not an indication that you have incorrectly configured the page.
+
+    To disable the preview button, navigate to Structure > Content Types > JBrowse Instance > edit and set the "Submission for settings" > "Preview before submitting" to "Disabled".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,3 +19,4 @@ This package of modules integrates `GMOD JBrowse <https://jbrowse.org/>`_ into y
 
     guide/install
     guide/jbrowse_mgmt
+    guide/instance_page

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -14,6 +14,7 @@ function tripal_jbrowse_mgmt_get_settings() {
     'bin_path' => '',
     'link' => '',
     'data_dir' => '',
+    'data_path' => '',
     'menu_template' => [],
   ];
 
@@ -405,8 +406,11 @@ function tripal_jbrowse_mgmt_build_http_query($instance) {
     }, $tracks));
   }
 
+  $settings = tripal_jbrowse_mgmt_get_settings();
+  $data_path = (empty($settings['data_path'])) ? 'data' : '/' . $settings['data_path'];
+
   return [
-    'data' => "data/$path/data",
+    'data' => "$data_path/$path/data",
     'tracks' => $tracks_path,
   ];
 }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_configure.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_configure.form.inc
@@ -12,7 +12,7 @@ function tripal_jbrowse_mgmt_configure_form($form, &$form_state) {
     '#type' => 'markup',
     '#prefix' => '<p>',
     '#markup' => t(
-      'This form allows administrators to control 
+      'This form allows administrators to control
       where JBrowse lives on the server.'
     ),
     '#suffix' => '</p>',
@@ -23,12 +23,23 @@ function tripal_jbrowse_mgmt_configure_form($form, &$form_state) {
   $form['data_dir'] = [
     '#title' => t('Data Directory'),
     '#description' => t(
-      'Absolute path to where data directories should live. 
+      'Absolute path to where data directories should live.
        This directory must be accessible by the apache user.'
     ),
     '#type' => 'textfield',
     '#maxlength' => 255,
     '#default_value' => $settings['data_dir'],
+    '#required' => TRUE,
+  ];
+
+  $form['data_path'] = [
+    '#title' => t('Data Path'),
+    '#description' => t(
+      'Relative path to where data directories lives relative to the web browser root.'
+    ),
+    '#type' => 'textfield',
+    '#maxlength' => 255,
+    '#default_value' => $settings['data_path'],
     '#required' => TRUE,
   ];
 
@@ -59,7 +70,7 @@ function tripal_jbrowse_mgmt_configure_form($form, &$form_state) {
   $form['menu_template'] = [
     '#title' => t('Default menuTemplate'),
     '#description' => t(
-      'Default menuTemplate in the trackList.json file. See 
+      'Default menuTemplate in the trackList.json file. See
        the JBrowse documentation for more info.'
     ),
     '#type' => 'textarea',
@@ -146,6 +157,7 @@ function tripal_jbrowse_mgmt_configure_form_submit($form, &$form_state) {
 
   $settings = [
     'data_dir' => rtrim($values['data_dir'], '/'),
+    'data_path' => trim($values['data_path'], '/'),
     'bin_path' => $bin_path,
     'link' => $values['link'],
     'menu_template' => $menu_template,


### PR DESCRIPTION
Issue #20 

I tried the following:
1. Configure Tripal JBrowse Management with data directory within JBrowse directory as expected.
2. Created an instance
3. Changed the data directory configuration
4. Created a track for the instance -new config was used.
5. Created a new instance -new config was used.
6. **Checked the launch for both instances: `data/genus-species/data` was used.**

This PR fixs the bug in 6 above as well as updates documentation to make it more clear that JBrowse needs to be installed before the module is used.