### PR TITLE
Add option of Symbolic Link for Track File upload

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -381,17 +381,26 @@ function tripal_jbrowse_mgmt_move_file($file, $path = NULL) {
  *   File path of the source file.
  * @param $destination
  *   File path to the destination directory.
- *
+ * @param $symbolic_link
+ *   bool indicates create symbolic_link or copy
  * @return bool
  */
-function tripal_jbrowse_mgmt_copy_file($source, $destination) {
+function tripal_jbrowse_mgmt_copy_file($source, $destination, $sym_link) {
   if (empty($destination)) {
     throw new Exception('Please provide a valid destination path to copy the source to.');
   }
 
   file_prepare_directory($destination, FILE_CREATE_DIRECTORY);
-  return file_unmanaged_copy($source, $destination, FILE_EXISTS_ERROR);
+  if (isset($sym_link) AND ($sym_link == true)){
+    $destination_symlink = $destination.'/'.basename($source);
+    return symlink($source, $destination_symlink);
+  }
+  else{
+    return file_unmanaged_copy($source, $destination, FILE_EXISTS_ERROR);
+  }
+
 }
+
 
 /**
  * Build the http query for a given instance to link to JBrowse.

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -94,11 +94,16 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
     ],
   ];
 
+  $form['data']['symbolic_link'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Symbolic Link'),
+    '#description' => t('Create a symbolic link rather than make a copy of the file.'),
+  ];
+
   $form['submit'] = [
     '#type' => 'submit',
     '#value' => 'Add New Track',
   ];
-
   return $form;
 }
 
@@ -120,6 +125,7 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
   $instance = tripal_jbrowse_mgmt_get_instance($values['instance_id']);
   $data = $settings['data_dir'];
   $file_type = $values['file_type'];
+  $symbolic_link = $values['symbolic_link'];
   $path = NULL;
 
   $base_path = $data . '/' . tripal_jbrowse_mgmt_make_slug($instance->title) . '/data';
@@ -162,11 +168,11 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
             }
             else {
               try {
-                if (!tripal_jbrowse_mgmt_copy_file($file_gz[0], $path)) {
+                if (!tripal_jbrowse_mgmt_copy_file($file_gz[0], $path, $symbolic_link)) {
                   form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path);
                 }
                 else {
-                  if (!tripal_jbrowse_mgmt_copy_file($file_tbi[0], $path)) {
+                  if (!tripal_jbrowse_mgmt_copy_file($file_tbi[0], $path, $symbolic_link)) {
                     form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path);
                   }
                 }
@@ -229,7 +235,7 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
         }
         else {
           try {
-            if (!tripal_jbrowse_mgmt_copy_file($local_file, $path)) {
+            if (!tripal_jbrowse_mgmt_copy_file($local_file, $path, $symbolic_link)) {
               form_set_error('file_path', 'Failed to copy file ' . $local_file . ' to ' . $path);
             }
           } catch (Exception $exception) {

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -97,7 +97,7 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
   $form['data']['symbolic_link'] = [
     '#type' => 'checkbox',
     '#title' => t('Symbolic Link'),
-    '#description' => t('Create a symbolic link rather than make a copy of the file.'),
+    '#description' => t('Create a symbolic link rather than make a copy of the file. This only applies when a path on the server is supplied.'),
   ];
 
   $form['submit'] = [


### PR DESCRIPTION
How to test:
1. change your moduel of my [fork of tripal_jbrowse](https://github.com/Jiu9Shen/tripal_jbrowse.git) and swithc to branch: `symbolic_link_4_upload_file`
2. install this module on your site 
3. once the module is available, create an instance first, then go to 

> Home » Administration » Tripal » Extensions » Tripal JBrowse Management

 Fill in the form to add a new track, its recommended to add a gff3 track(CanvasFeatures). vcf tracks will be tested in next PR.
![Screenshot from 2019-12-03 15-44-24](https://user-images.githubusercontent.com/26550071/70092785-a9940b80-15e4-11ea-929a-188c21bacffe.png)

**Don't forget to check the Symbolic Link box!**

4. run the job to check if track is created successfully, also go to `your_site/sites/all/tools/jbrowse/data/your_instance/data` so check if a copy or symblic link is created