### PR TITLE
Textfield maxlength change to fix longer path

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -91,6 +91,7 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
   $form['data']['ref_seq_path'] = [
     '#type' => 'textfield',
     '#title' => t('OR Path to File on Server'),
+    '#maxlength' => 255,
     '#description' => t(
       'This path will be ignored if a file is provided above. Ex: sites/default/files/file.fasta or /data/file.fasta'
     ),

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -76,6 +76,7 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
     '#type' => 'textfield',
     '#title' => t('- OR Path to File on Server -'),
     '#description' => t('This path will be ignored if a file is provided above. Ex: sites/default/files/file.fasta or /data/file.fasta'),
+    '#maxlength' => 255,
     '#states' => [
       'invisible' => [
         ':input[name="file_type"]' => ['value' => 'vcf'],
@@ -87,6 +88,7 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
     '#type' => 'textfield',
     '#title' => t('- OR Path to Directory on Server -'),
     '#description' => t('This path will be ignored if a file is provided above. ' . 'The directory must contain both the .tbi and .gz files.'),
+    '#maxlength' => 255,
     '#states' => [
       'visible' => [
         ':input[name="file_type"]' => ['value' => 'vcf'],


### PR DESCRIPTION
Easy fix, add "#maxlength" => 255 to textfield in form.
Test:
3 locations have path input:

Tripal JBrowse Management -> moduel settings (configuration) (no change made, already set to 255)

add new instance

add new track

Please test with a string with more than 128 characters.