### PR TITLE
Including instance_id in url to give each instance a unique link

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -387,6 +387,22 @@ function tripal_jbrowse_mgmt_delete_track_form_submit($form, &$form_state) {
 function tripal_jbrowse_mgmt_json_editor_advance_form($form, &$form_state, $track_id) {
   $track = tripal_jbrowse_mgmt_get_track($track_id);
 
+  if (empty($track)) {
+    drupal_not_found();
+    return $form;
+  }
+
+  drupal_set_title('Edit Track Json: ' . $track->label);
+
+  $breadcrumb = array();
+  $breadcrumb[] = l('Home', '');
+  $breadcrumb[] = l('Administration', 'admin');
+  $breadcrumb[] = l('Tripal', 'admin/tripal');
+  $breadcrumb[] = l('Extensions', 'admin/tripal/extension');
+  $breadcrumb[] = l('Tripal JBrowse', 'admin/tripal/extension/tripal_jbrowse/management');
+  $breadcrumb[] = l('Instance', 'admin/tripal/extension/tripal_jbrowse/management/instances/'.$track->instance_id);
+  drupal_set_breadcrumb($breadcrumb);
+
   if (!$track->id) {
     $form['error'] = [
       '#type' => 'item',

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.admin.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.admin.inc
@@ -35,6 +35,8 @@ function tripal_jbrowse_page_settings_form($form, $form_state) {
     $options[$key] = [
       'genus' => $instance->organism->genus,
       'species' => $instance->organism->species,
+      'analysis' => $instance->analysis->name ?? 'Not Provided',
+      'description' => $instance->description,
     ];
   }
   // Determine the default value.
@@ -48,6 +50,8 @@ function tripal_jbrowse_page_settings_form($form, $form_state) {
     '#header' => [
       'genus' => t('Genus'),
       'species' => t('Species'),
+      'analysis' => t('Analysis'),
+      'description' => t('Description')
     ],
     '#options' => $options,
     '#empty' => t('No JBrowse Instances available. Please add one through the "List Instances" page.'),
@@ -67,7 +71,6 @@ function tripal_jbrowse_page_settings_form($form, $form_state) {
  */
 function tripal_jbrowse_page_settings_form_submit($form, $form_state) {
   $values = $form_state['values'];
-
   // General Settings.
   variable_set(
     'trpjbrowse_page_embed',

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.api.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.api.inc
@@ -8,7 +8,6 @@
  * Retrieve the instance id based on the organism.
  */
 function tripal_jbrowse_page_get_instance_id($conditions, $options) {
-
   // First retrieve the organism_id.
   $organism_id = chado_query('SELECT organism_id FROM {organism} WHERE genus=:genus AND species=:species',
     [

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.listing.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.listing.inc
@@ -18,7 +18,7 @@ function tripal_jbrowse_page_listing_page() {
   // Add the URL for each to link to.
   foreach($instances as $k => $instance) {
     if (tripal_jbrowse_page_is_instance_public($instance->id)) {
-      $instances[$k]->url = url('jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species, ['absolute' => TRUE]);
+      $instances[$k]->url = url('jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species.'/'.$instance->id, ['absolute' => TRUE]);
     }
     else {
       unset($instances[$k]);

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
@@ -7,7 +7,7 @@
 /**
  * Redirect to the JBrowse Instance.
  */
-function tripal_jbrowse_page_page($scientific_name, $instance_id) {
+function tripal_jbrowse_page_page($scientific_name, $instance_id = NULL) {
   if($instance_id){
     $instance = tripal_jbrowse_mgmt_get_instance($instance_id);
   }

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
@@ -7,13 +7,18 @@
 /**
  * Redirect to the JBrowse Instance.
  */
-function tripal_jbrowse_page_page($scientific_name) {
-  list($genus, $species) = explode('-', $scientific_name);
-  $instance = tripal_jbrowse_page_get_instance_id([
-    'genus' => $genus,
-    'species' => $species
-  ],
-  ['load_instance' => TRUE]);
+function tripal_jbrowse_page_page($scientific_name, $instance_id) {
+  if($instance_id){
+    $instance = tripal_jbrowse_mgmt_get_instance($instance_id);
+  }
+  else{
+    list($genus, $species) = explode('-', $scientific_name);
+    $instance = tripal_jbrowse_page_get_instance_id([
+      'genus' => $genus,
+      'species' => $species
+    ],
+    ['load_instance' => TRUE]);
+  }
 
   // Determine Query paramters.
   $query_params = tripal_jbrowse_mgmt_build_http_query($instance);

--- a/tripal_jbrowse_page/tripal_jbrowse_page.module
+++ b/tripal_jbrowse_page/tripal_jbrowse_page.module
@@ -26,12 +26,12 @@ function tripal_jbrowse_page_menu() {
     if (tripal_jbrowse_page_is_instance_public($instance->id)) {
 
       // Create the menu item.
-      $path = 'jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species . '/' . $instance->id;
+      $path = 'jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species;
       $items[$path] = [
         'title' => $instance->title,
         'description' => $instance->description,
         'page callback' => 'tripal_jbrowse_page_page',
-        'page arguments' => [1, 2],
+        'page arguments' => [1, $instance->id],
         'access arguments' => ['access content'],
         'file' => 'includes/tripal_jbrowse_page.page.inc',
         'type' => MENU_SUGGESTED_ITEM,

--- a/tripal_jbrowse_page/tripal_jbrowse_page.module
+++ b/tripal_jbrowse_page/tripal_jbrowse_page.module
@@ -31,7 +31,7 @@ function tripal_jbrowse_page_menu() {
         'title' => $instance->title,
         'description' => $instance->description,
         'page callback' => 'tripal_jbrowse_page_page',
-        'page arguments' => [1, $instance->id],
+        'page arguments' => [1, 2],
         'access arguments' => ['access content'],
         'file' => 'includes/tripal_jbrowse_page.page.inc',
         'type' => MENU_SUGGESTED_ITEM,

--- a/tripal_jbrowse_page/tripal_jbrowse_page.module
+++ b/tripal_jbrowse_page/tripal_jbrowse_page.module
@@ -26,12 +26,12 @@ function tripal_jbrowse_page_menu() {
     if (tripal_jbrowse_page_is_instance_public($instance->id)) {
 
       // Create the menu item.
-      $path = 'jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species;
+      $path = 'jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species . '/' . $instance->id;
       $items[$path] = [
         'title' => $instance->title,
         'description' => $instance->description,
         'page callback' => 'tripal_jbrowse_page_page',
-        'page arguments' => [1],
+        'page arguments' => [1, 2],
         'access arguments' => ['access content'],
         'file' => 'includes/tripal_jbrowse_page.page.inc',
         'type' => MENU_SUGGESTED_ITEM,


### PR DESCRIPTION
This PR is related to issue #47.

How to test:
1. install tripal_jbrowse on your site
2. create more than one instances which belong to same species
3. go to your_site/jbrowse to check if created instances  can be shown properly
4. check each instance link if it can direct to proper JBrowse