### PR TITLE
allow new tracks with existed file by selecting Symbolic Link

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -428,7 +428,11 @@ function tripal_jbrowse_mgmt_copy_file($source, $destination, $sym_link) {
   file_prepare_directory($destination, FILE_CREATE_DIRECTORY);
   if (isset($sym_link) AND ($sym_link == true)){
     $destination_symlink = $destination.'/'.basename($source);
-    return symlink($source, $destination_symlink);
+    if (file_exists($destination_symlink)){
+      return TRUE;
+    }else{
+      return symlink($source, $destination_symlink);
+    }
   }
   else{
     return file_unmanaged_copy($source, $destination, FILE_EXISTS_ERROR);

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -99,7 +99,7 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
   $form['data']['symbolic_link'] = [
     '#type' => 'checkbox',
     '#title' => t('Symbolic Link'),
-    '#description' => t('Create a symbolic link rather than make a copy of the file. This only applies when a path on the server is supplied.'),
+    '#description' => t('Create a symbolic link rather than make a copy of the file. This only applies when a path on the server is supplied.<br>Please have Symbolic Link selected if the same file is used for new track.'),
   ];
 
   $form['submit'] = [
@@ -173,11 +173,11 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
             else {
               try {
                 if (!tripal_jbrowse_mgmt_copy_file($file_gz[0], $path, $symbolic_link)) {
-                  form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path);
+                  form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
                 }
                 else {
                   if (!tripal_jbrowse_mgmt_copy_file($file_index[0], $path, $symbolic_link)) {
-                    form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path);
+                    form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
                   }
                 }
               } catch (Exception $exception) {
@@ -240,10 +240,10 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
         else {
           try {
             if (!tripal_jbrowse_mgmt_copy_file($local_file, $path, $symbolic_link)) {
-              form_set_error('file_path', 'Failed to copy file ' . $local_file . ' to ' . $path);
+              form_set_error('file_path', 'Failed to copy file ' . $local_file . ' to ' . $path. '. If this track is expected to create by existed file, please have Symbolic Link selected.');
             }
           } catch (Exception $exception) {
-            form_set_error('file_path', 'Failed to copy file ' . $local_file . ' to ' . $path);
+            form_set_error('file_path', 'Failed to copy file ' . $local_file . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
           }
         }
       }


### PR DESCRIPTION
This PR is related to issue #45 

What this PR does:
when Symbolic Link checkbox is selected, won't report error if file(path) provided by user already exist in tripal_jbrowse

This PR is tested on @Jiu9Shen local KP site with gff3, vcf, bigwig files already.

How to TEST:
1. install tripal_jbrowse
2. create one instance with multiple types of tracks
3. try to create tracks again with same file but different Track Label:
  w Symbolic Link checked: track can be created without any error
  w/o Symbolic Link checked: two error message should appear: 
       a. by drupal api file_unmanaged_copy
       b. customized message includes unable to move file and use symbolic link to create new track with existed file
