### PR TITLE
Add analysis and description to the embedded page.

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -84,6 +84,12 @@ function tripal_jbrowse_mgmt_get_instances($conditions = NULL) {
           [':id' => $instance->analysis_id])->fetchObject();
       }
       $instance->analysis = $analysis[$instance->analysis_id];
+      $instance->analysis->entity_id = chado_get_record_entity_by_table(
+        'analysis', $instance->analysis_id);
+      $instance->analysis->url = NULL;
+      if ($instance->analysis->entity_id) {
+        $instance->analysis->url = url('/bio_data/' . $instance->analysis->entity_id);
+      }
     }
 
   }

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
@@ -31,9 +31,10 @@ function tripal_jbrowse_page_page($scientific_name, $instance_id = NULL) {
   $settings = tripal_jbrowse_mgmt_get_settings();
   $url = url($settings['link'],['query' => $query_params]);
 
+  // Either embed the page or redirect to the full JBrowse based on configuration.
   if (variable_get('trpjbrowse_page_embed', 1)) {
     drupal_add_css(drupal_get_path('module', 'tripal_jbrowse_page') . '/theme/tripal_jbrowse_page.css');
-    return theme('jbrowse_instance_embedded_page', ['url' => $url]);
+    return theme('jbrowse_instance_embedded_page', ['url' => $url, 'instance' => $instance]);
   }
   else {
     drupal_goto($url, array('external' => TRUE));

--- a/tripal_jbrowse_page/theme/jbrowse-instance--embedded.tpl.php
+++ b/tripal_jbrowse_page/theme/jbrowse-instance--embedded.tpl.php
@@ -1,4 +1,23 @@
+<?php
+/**
+ * Provides an embedded JBrowse instance.
+ *
+ * Variables:
+ *  - $url: the url of the JBrowse instance.
+ *  - $instance: an object describing the jbrowse instance.
+ */
+?>
 
+<?php if ($instance->analysis_id > 0) : ?>
+  <h3>Sequence Assembly:
+    <?php if ($instance->analysis->url) : ?>
+      <a href="<?php print $instance->analysis->url; ?>"><?php print $instance->analysis->name; ?></a>
+    <?php else: ?>
+      <?php print $instance->analysis->name; ?>
+    <?php endif; ?>
+  </h3>
+<?php endif; ?>
+<p><?php print $instance->description; ?></p>
 <div id="JBrowseInstance">
   <iframe src="<?php print $url;?>" width="100%" height="100%">
   </iframe>


### PR DESCRIPTION
This PR relates to Issue #52.

Specifically, it adds the `analysis.name` link and instance description to the embedded JBrowse page. This allows JBrowse instances with the same organism but different analysis to be visually told apart.

## Testing
Given two instances for the same organism where one does not have an analysis attached.
 - Go to `[yourtripalsite]/jbrowse` and launch each JBrowse
 - Check that there are no errors and that you can easily tell the tabs appart
 - Check if the instance has an analysis that it is listed on the page as a link to the analysis.
 - Check that if the instance does not have an analysis there are no errors.
 - Check that the description is listed as well.

## Note
The analysis labelled "Sequence Assembly" rather then "Analysis" to make it more intuitive. Another PR will change the word "Analysis" to "Sequence Assembly" throughout the module.