### PR TITLE
Make analysis a link and switch to "Sequence Assembly"

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -84,6 +84,12 @@ function tripal_jbrowse_mgmt_get_instances($conditions = NULL) {
           [':id' => $instance->analysis_id])->fetchObject();
       }
       $instance->analysis = $analysis[$instance->analysis_id];
+      $instance->analysis->entity_id = chado_get_record_entity_by_table(
+        'analysis', $instance->analysis_id);
+      $instance->analysis->url = NULL;
+      if ($instance->analysis->entity_id) {
+        $instance->analysis->url = url('/bio_data/' . $instance->analysis->entity_id);
+      }
     }
 
   }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_add.form.inc
@@ -48,14 +48,14 @@ function tripal_jbrowse_mgmt_add_form($form, &$form_state) {
     'vocabulary'=>'operation',
     'accession'=>'2945',
   ]);
-  
+
   $analysis_bundle_entity = tripal_load_bundle_entity([
     'term_id'=>$analysis_term_entity->id,
   ]);
 
   $form['analysis'] = [
-    '#title' => t('Analysis'),
-    '#description' => 'Select the analysis to which this instance will be related. Analysis can be created in '.l('Add Tripal Content', 'bio_data/add/' . $analysis_bundle_entity->id).' if wanted analysis is not available.<br><strong>Please choose analysis carefully</strong> since it can not change once instance is created.',
+    '#title' => t('Sequence Assembly'),
+    '#description' => 'Select the analysis which describes the sequence assembly used as the backbone for this JBrowse instance. An analysis can be created in '.l('Add Tripal Content', 'bio_data/add/' . $analysis_bundle_entity->id).' if it is not already available.<br><strong>Please choose analysis carefully</strong> since it can not change once instance is created.',
     '#type' => 'textfield',
     '#autocomplete_path' => 'admin/tripal/extension/tripal_jbrowse/management/instances/analysis/autocomplete',
     '#weight' => -6,

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_instance.page.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_instance.page.inc
@@ -36,7 +36,7 @@ function tripal_jbrowse_mgmt_instance_page($instance_id) {
         'header' => ['Key', 'Value'],
         'rows' => [
           ['Instance Name', $instance->title],
-          ['Analysis Name', $instance->analysis->name ?? 'Not provided'],
+          ['Sequence Assembly', $instance->analysis->name ?? 'Not provided'],
           ['Created At', date('m/d/Y', $instance->created_at)],
           [
             'Organism',

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_list.page.inc
@@ -29,7 +29,7 @@ function tripal_jbrowse_mgmt_instances_page() {
 
   $header = [
     'Organism',
-    'Analysis',
+    'Sequence Assembly',
     'Submitter',
     'Description',
     'Tracks',

--- a/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
+++ b/tripal_jbrowse_page/includes/tripal_jbrowse_page.page.inc
@@ -31,9 +31,10 @@ function tripal_jbrowse_page_page($scientific_name, $instance_id = NULL) {
   $settings = tripal_jbrowse_mgmt_get_settings();
   $url = url($settings['link'],['query' => $query_params]);
 
+  // Either embed the page or redirect to the full JBrowse based on configuration.
   if (variable_get('trpjbrowse_page_embed', 1)) {
     drupal_add_css(drupal_get_path('module', 'tripal_jbrowse_page') . '/theme/tripal_jbrowse_page.css');
-    return theme('jbrowse_instance_embedded_page', ['url' => $url]);
+    return theme('jbrowse_instance_embedded_page', ['url' => $url, 'instance' => $instance]);
   }
   else {
     drupal_goto($url, array('external' => TRUE));

--- a/tripal_jbrowse_page/theme/jbrowse-instance--embedded.tpl.php
+++ b/tripal_jbrowse_page/theme/jbrowse-instance--embedded.tpl.php
@@ -1,4 +1,23 @@
+<?php
+/**
+ * Provides an embedded JBrowse instance.
+ *
+ * Variables:
+ *  - $url: the url of the JBrowse instance.
+ *  - $instance: an object describing the jbrowse instance.
+ */
+?>
 
+<?php if ($instance->analysis_id > 0) : ?>
+  <h3>Sequence Assembly:
+    <?php if ($instance->analysis->url) : ?>
+      <a href="<?php print $instance->analysis->url; ?>"><?php print $instance->analysis->name; ?></a>
+    <?php else: ?>
+      <?php print $instance->analysis->name; ?>
+    <?php endif; ?>
+  </h3>
+<?php endif; ?>
+<p><?php print $instance->description; ?></p>
 <div id="JBrowseInstance">
   <iframe src="<?php print $url;?>" width="100%" height="100%">
   </iframe>

--- a/tripal_jbrowse_page/theme/jbrowse-instance--public-listing.tpl.php
+++ b/tripal_jbrowse_page/theme/jbrowse-instance--public-listing.tpl.php
@@ -8,7 +8,12 @@
       <h3><?php print l($instance->title, $instance->url); ?></h3>
       <p><?php
       if(property_exists($instance, 'analysis')) {
-        print 'Analysis: ' . $instance->analysis->name . "<br>";
+        if ($instance->analysis->url) {
+          print 'Sequence Assembly: ' . l($instance->analysis->name, $instance->analysis->url) . "<br>";
+        }
+        else {
+          print 'Sequence Assembly: ' . $instance->analysis->name . "<br>";
+        }
       }
       print $instance->description; ?></p>
       <span class="jbrowse-launch-link"><?php print l('Launch JBrowse', $instance->url); ?></span>


### PR DESCRIPTION
This PR is related to Issue #51 

**THIS PR IS DEPENDANT ON #53**

Specifically, It makes a the analysis a link on the embedded JBrowse listing (`[yourdrupalsite]/jbrowse]`) and changes the wording of Analysis in the UI to "Sequence Assembly" to be more intuitive to the user and provide more guidance to the administrator.

## Testing
- Go to `[yourdrupalsite]/jbrowse]` and check all analysis listed are links. Check there are no errors if instances do not have analysis.
- Add/Edit/Register an instance and check the help text guides you to attach a sequence assembly analysis.
- Check the administrative listing also refers to it as a sequence assembly.