### PR TITLE
46 alignments

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -731,8 +731,6 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
    $local_directory = isset($values['dir_path']) ? $values['dir_path'] : NULL;
    $symbolic_link = $values['symbolic_link'];
 
-   dpm($path, '$path in validation');
-
    if (empty($file) && empty($index) && empty($local_directory)) {
      form_set_error('Please provide a local directory path or upload files.');
    }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -612,6 +612,7 @@ function tripal_jbrowse_mgmt_get_track_types() {
   return [
     'FeatureTrack',
     'CanvasFeatures',
+    'Alignment',
     'HTMLFeatures',
     'HTMLVariants',
     'XYPlot',

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -734,18 +734,31 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
    if (empty($file) && empty($index) && empty($local_directory)) {
      form_set_error('Please provide a local directory path or upload files.');
    }
-   elseif (empty($file) && empty($index) && !empty($local_dir)) {
-     if (!file_exists($local_dir)) {
+   elseif (empty($file) && empty($index) && !empty($local_directory)) {
+     if (!file_exists($local_directory)) {
        form_set_error('The directory provided does not exist.');
      }
      else {
-       if (!is_dir($local_dir)) {
+       if (!is_dir($local_directory)) {
          form_set_error('file_path',
            'The file provided is not a directory.');
        }
        else {
-         $file_file = glob($local_dir . '/*.[vcf.gz][bam][cram]');
-         $file_index = glob($local_dir . '/*.[csi][tbi][idx][bai][cram][crai]');
+         // Retrieve an array of data file and index
+         // to ensure there is only one of each.
+         $file_file = [];
+         $file_index = [];
+         foreach (scandir($local_directory) as $f) {
+           $fparts = pathinfo($f);
+
+           if (in_array($fparts['extension'], ['gz', 'bam', 'cram'])) {
+             $file_file[] = $f;
+           }
+           if (in_array($fparts['extension'], ['csi','tbi','idx','bai','crai'])) {
+             $file_index[] = $f;
+           }
+         }
+         // CHECK: Only a single data file and index.
          if (count($file_file) != 1 || count($file_index) != 1) {
            form_set_error('file_path',
              'Please provide a directory with exactly one data file and one index file.');
@@ -777,7 +790,7 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
    else {
      $file_data_uploaded = tripal_jbrowse_mgmt_upload_file('file');
      if (!$file_data_uploaded) {
-       form_set_error('file', 'Unable to upload file');
+       form_set_error('file', 'Unable to upload file.');
      }
      else {
        $file_data_uploaded = tripal_jbrowse_mgmt_move_file($file_data_uploaded, $path);
@@ -791,7 +804,7 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
 
      $index_uploaded = tripal_jbrowse_mgmt_upload_file('file2');
      if (!$index_uploaded) {
-       form_set_error('file2', 'Unable to upload file');
+       form_set_error('file2', 'Unable to upload index.');
      }
      else {
        $index_uploaded = tripal_jbrowse_mgmt_move_file($index_uploaded, $path);

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -731,6 +731,8 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
    $local_directory = isset($values['dir_path']) ? $values['dir_path'] : NULL;
    $symbolic_link = $values['symbolic_link'];
 
+   dpm($path, '$path in validation');
+
    if (empty($file) && empty($index) && empty($local_directory)) {
      form_set_error('Please provide a local directory path or upload files.');
    }
@@ -746,19 +748,19 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
        else {
          // Retrieve an array of data file and index
          // to ensure there is only one of each.
-         $file_file = [];
-         $file_index = [];
+
          foreach (scandir($local_directory) as $f) {
            $fparts = pathinfo($f);
 
            if (in_array($fparts['extension'], ['gz', 'bam', 'cram'])) {
-             $file_file[] = $f;
+             $file_file[] = $local_directory . '/' . $f;
            }
            if (in_array($fparts['extension'], ['csi','tbi','idx','bai','crai'])) {
-             $file_index[] = $f;
+             $file_index[] = $local_directory . '/' . $f;
            }
          }
          // CHECK: Only a single data file and index.
+
          if (count($file_file) != 1 || count($file_index) != 1) {
            form_set_error('file_path',
              'Please provide a directory with exactly one data file and one index file.');

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -766,11 +766,11 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
          else {
            try {
              if (!tripal_jbrowse_mgmt_copy_file($file_file[0], $path, $symbolic_link)) {
-               form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
+               form_set_error('file_path', 'Failed to copy file' . $file_file[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
              }
              else {
                if (!tripal_jbrowse_mgmt_copy_file($file_index[0], $path, $symbolic_link)) {
-                 form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
+                 form_set_error('file_path', 'Failed to copy file' . $file_index[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
                }
              }
            } catch (Exception $exception) {

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -710,3 +710,22 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
     ->condition('instance_id', $id)
     ->execute()->fetchAllKeyed(0,1);
 }
+
+
+/**
+ * validate folder upload (file with index)
+ * eg. vcf, bam, cram
+ *
+ * @param $file
+ *   the path and file name of upload file
+ * @param $index
+ *   the path and file name of upload file
+ * @param $local_directory
+ *   the path and file name of upload file
+ * @return
+ *   warning message or NULL if no warning
+ */
+
+ function tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $local_directory) {
+
+ }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -375,7 +375,7 @@ function tripal_jbrowse_mgmt_make_slug($string) {
  */
 function tripal_jbrowse_mgmt_upload_file($field) {
   $file = file_save_upload($field, [
-    'file_validate_extensions' => ['fasta faa fna fastq txt gff vcf wig gz tbi bw'],
+    'file_validate_extensions' => ['fasta faa fna fastq txt gff vcf wig gz tbi bw bam bai cram'],
     // Make it 20 GB max.
     'file_validate_size' => [1024 * 1024 * 1024 * 20],
   ]);
@@ -726,6 +726,82 @@ function tripal_jbrowse_mgmt_get_instance_properties($id) {
  *   warning message or NULL if no warning
  */
 
- function tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $local_directory) {
+ function tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state) {
+   $values = $form_state['values'];
+   $local_directory = isset($values['dir_path']) ? $values['dir_path'] : NULL;
+   $symbolic_link = $values['symbolic_link'];
 
+   if (empty($file) && empty($index) && empty($local_directory)) {
+     form_set_error('Please provide a local directory path or upload files.');
+   }
+   elseif (empty($file) && empty($index) && !empty($local_dir)) {
+     if (!file_exists($local_dir)) {
+       form_set_error('The directory provided does not exist.');
+     }
+     else {
+       if (!is_dir($local_dir)) {
+         form_set_error('file_path',
+           'The file provided is not a directory.');
+       }
+       else {
+         $file_file = glob($local_dir . '/*.[vcf.gz][bam][cram]');
+         $file_index = glob($local_dir . '/*.[csi][tbi][idx][bai][cram][crai]');
+         if (count($file_file) != 1 || count($file_index) != 1) {
+           form_set_error('file_path',
+             'Please provide a directory with exactly one data file and one index file.');
+         }
+         else {
+           try {
+             if (!tripal_jbrowse_mgmt_copy_file($file_file[0], $path, $symbolic_link)) {
+               form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
+             }
+             else {
+               if (!tripal_jbrowse_mgmt_copy_file($file_index[0], $path, $symbolic_link)) {
+                 form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
+               }
+             }
+           } catch (Exception $exception) {
+             form_set_error($exception->getMessage());
+           }
+
+         }
+       }
+     }
+   }
+   elseif (empty($file) && !empty($index)) {
+     form_set_error('file', 'Please upload both a data file and an index file.');
+   }
+   elseif (!empty($file) && empty($index)) {
+     form_set_error('file2', 'Please upload both a data file and an index file.');
+   }
+   else {
+     $file_data_uploaded = tripal_jbrowse_mgmt_upload_file('file');
+     if (!$file_data_uploaded) {
+       form_set_error('file', 'Unable to upload file');
+     }
+     else {
+       $file_data_uploaded = tripal_jbrowse_mgmt_move_file($file_data_uploaded, $path);
+       if (!isset($file_data_uploaded)) {
+         form_set_error('file', 'Failed to move data file to ' . $path . '.');
+       }
+       else {
+         $form_state['values']['uploaded_file_data'] = $file_data_uploaded;
+       }
+     }
+
+     $index_uploaded = tripal_jbrowse_mgmt_upload_file('file2');
+     if (!$index_uploaded) {
+       form_set_error('file2', 'Unable to upload file');
+     }
+     else {
+       $index_uploaded = tripal_jbrowse_mgmt_move_file($index_uploaded, $path);
+       if (!isset($index_uploaded)) {
+         form_set_error('file2', 'Failed to move index file to ' . $path . '.');
+       }
+       else {
+         $form_state['values']['uploaded_file_index'] = $index_uploaded;
+       }
+     }
+   }
+   return $form_state;
  }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
@@ -111,6 +111,34 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
       tripal_jbrowse_mgmt_save_json($instance, $json);
       break;
 
+    case 'Alignment':
+      $json = tripal_jbrowse_mgmt_get_json($instance);
+      $directory = 'bam';
+      $file_name = $track->file;
+      if (is_dir($track->file)) {
+        $file_name = glob($track->file . '/' . '*.[bam][cram]')[0];
+      }
+      $file_name = pathinfo($file_name)['basename'];
+
+      $track_in_json = [
+        'label' => tripal_jbrowse_mgmt_make_slug($track->label),
+        'key' => $track->label,
+        'urlTemplate' => $directory . '/' . $file_name,
+        'type' => 'JBrowse/View/Track/Alignment2',
+      ];
+
+      $extension = pathinfo($file_name)['extension'];
+      switch($extension){
+        case 'bam':
+          $track_in_json['storeClass'] = 'JBrowse/Store/SeqFeature/BAM';
+          break;
+        case 'cram':
+          $track_in_json['storeClass'] = 'JBrowse/Store/SeqFeature/CRAM';
+          break;
+      }
+      tripal_jbrowse_mgmt_save_json($instance, $json);
+      break;
+
     case 'XYPlot':
       $json = tripal_jbrowse_mgmt_get_json($instance);
       $basename = pathinfo($track->file)['basename'];

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
@@ -78,7 +78,7 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
       $file_name = $track->file;
       if (is_dir($track->file)) {
         $file_name = glob($track->file . '/' . '*.vcf.gz')[0];
-        $index_name = glob($track->file . '/' . '*.vcf.gz.[tbi][csi][idx]')[0];
+        $index_name = glob($track->file . '/' . '*.vcf.gz.[cti][sbd][ix]')[0];
       }
       $file_name = pathinfo($file_name)['basename'];
 

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
@@ -124,7 +124,7 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
         'label' => tripal_jbrowse_mgmt_make_slug($track->label),
         'key' => $track->label,
         'urlTemplate' => $directory . '/' . pathinfo($file_name)['basename'],
-        'type' => 'JBrowse/View/Track/Alignment2',
+        'type' => 'JBrowse/View/Track/Alignments2',
       ];
 
       $extension = pathinfo($file_name)['extension'];

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
@@ -78,7 +78,7 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
       $file_name = $track->file;
       if (is_dir($track->file)) {
         $file_name = glob($track->file . '/' . '*.vcf.gz')[0];
-        $index_name = glob($track->file . '/' . '*.vcf.gz.[tci][bsd][ix]')[0];
+        $index_name = glob($track->file . '/' . '*.vcf.gz.[tbi][csi][idx]')[0];
       }
       $file_name = pathinfo($file_name)['basename'];
 
@@ -115,8 +115,12 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
       $json = tripal_jbrowse_mgmt_get_json($instance);
       $directory = 'bam';
       if (is_dir($track->file)) {
-        $file_name = glob($track->file . '/' . '*.[bam][cram]')[0];
-        $index_file_name = glob($track->file . '/' . '*.[bai][csi][crai]')[0];
+        $file_name = glob($track->file . '/' . '*.bam')[0];
+        $index_file_name = glob($track->file . '/' . '*.bam.*')[0];
+        if (!$file_name) {
+          $file_name = glob($track->file . '/' . '*.cram')[0];
+          $index_file_name = glob($track->file . '/' . '*.cram.*')[0];
+         }
       }
 
       $track_in_json = [

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
@@ -114,10 +114,9 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
     case 'Alignment':
       $json = tripal_jbrowse_mgmt_get_json($instance);
       $directory = 'bam';
-      $file_name = $track->file;
       if (is_dir($track->file)) {
-        $file_name = glob($track->file . '/' . '*.bam')[0];
-        if (!$file_name) { $file_name = glob($track->file . '/' . '*.cram')[0]; }
+        $file_name = glob($track->file . '/' . '*.[bam][cram]')[0];
+        $index_file_name = glob($track->file . '/' . '*.[bai][csi][crai]')[0];
       }
 
       $track_in_json = [
@@ -126,7 +125,16 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
         'urlTemplate' => $directory . '/' . pathinfo($file_name)['basename'],
         'type' => 'JBrowse/View/Track/Alignments2',
       ];
+      $index_path_info = pathinfo($index_file_name);
+      switch($index_path_info['extension']){
+        case "bai":
+        $track_in_json['baiUrlTemplate'] = $directory . '/' . $index_path_info['basename'];
+        break;
 
+        case "csi":
+        $track_in_json['csiUrlTemplate'] = $directory . '/' . $index_path_info['basename'];
+        break;
+      }
       $extension = pathinfo($file_name)['extension'];
       switch($extension){
         case 'bam':

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_commands.inc
@@ -116,14 +116,14 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
       $directory = 'bam';
       $file_name = $track->file;
       if (is_dir($track->file)) {
-        $file_name = glob($track->file . '/' . '*.[bam][cram]')[0];
+        $file_name = glob($track->file . '/' . '*.bam')[0];
+        if (!$file_name) { $file_name = glob($track->file . '/' . '*.cram')[0]; }
       }
-      $file_name = pathinfo($file_name)['basename'];
 
       $track_in_json = [
         'label' => tripal_jbrowse_mgmt_make_slug($track->label),
         'key' => $track->label,
-        'urlTemplate' => $directory . '/' . $file_name,
+        'urlTemplate' => $directory . '/' . pathinfo($file_name)['basename'],
         'type' => 'JBrowse/View/Track/Alignment2',
       ];
 
@@ -136,6 +136,7 @@ function tripal_jbrowse_mgmt_cmd_add_track($track) {
           $track_in_json['storeClass'] = 'JBrowse/Store/SeqFeature/CRAM';
           break;
       }
+      $json['tracks'][] = $track_in_json;
       tripal_jbrowse_mgmt_save_json($instance, $json);
       break;
 

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -139,6 +139,9 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
   if ($file_type === 'vcf') {
     $path = $base_path . '/vcf';
   }
+  if (($file_type === 'bam') OR ($file_type === 'cram')){
+    $path = $base_path . '/bam';
+  }
   elseif ($file_type === 'bw') {
     $path = $base_path . '/wig';
   }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -165,7 +165,7 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
       $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
       break;
 
-    case 'carm':
+    case 'cram':
       $index = $_FILES['files']['tmp_name']['file2'];
       $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
       break;

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -67,7 +67,9 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
     '#title' => t('Index File'),
     '#states' => [
       'visible' => [
-        ':input[name="file_type"]' => ['value' => 'vcf'],
+        [':input[name="file_type"]' => ['value' => 'vcf'],],
+        [':input[name="file_type"]' => ['value' => 'bam'],],
+        [':input[name="file_type"]' => ['value' => 'cram'],],
       ],
     ],
   ];
@@ -79,7 +81,9 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
     '#maxlength' => 255,
     '#states' => [
       'invisible' => [
-        ':input[name="file_type"]' => ['value' => 'vcf'],
+        [':input[name="file_type"]' => ['value' => 'vcf'],],
+        [':input[name="file_type"]' => ['value' => 'bam'],],
+        [':input[name="file_type"]' => ['value' => 'cram'],],
       ],
     ],
   ];
@@ -91,7 +95,9 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
     '#maxlength' => 255,
     '#states' => [
       'visible' => [
-        ':input[name="file_type"]' => ['value' => 'vcf'],
+        [':input[name="file_type"]' => ['value' => 'vcf'],],
+        [':input[name="file_type"]' => ['value' => 'bam'],],
+        [':input[name="file_type"]' => ['value' => 'cram'],],
       ],
     ],
   ];

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -151,82 +151,17 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
   switch ($file_type) {
     case 'vcf':
       $index = $_FILES['files']['tmp_name']['file2'];
-      $local_dir = isset($values['dir_path']) ? $values['dir_path'] : NULL;
+      $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
+      break;
 
-      if (empty($file) && empty($index) && empty($local_dir)) {
-        form_set_error('file',
-          'Please provide a local directory path or upload files.');
-      }
-      elseif (empty($file) && empty($index) && !empty($local_dir)) {
-        if (!file_exists($local_dir)) {
-          form_set_error('file_path', 'The directory provided does not exist.');
-        }
-        else {
-          if (!is_dir($local_dir)) {
-            form_set_error('file_path',
-              'The file provided is not a directory.');
-          }
-          else {
-            $file_gz = glob($local_dir . '/*.vcf.gz');
-            $file_index = glob($local_dir . '/*.vcf.gz.[cti][sbd][ix]');
-            if (count($file_gz) != 1 || count($file_index) != 1) {
-              form_set_error('file_path',
-                'Please provide a directory with exactly one gz and one index file.');
-            }
-            else {
-              try {
-                if (!tripal_jbrowse_mgmt_copy_file($file_gz[0], $path, $symbolic_link)) {
-                  form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
-                }
-                else {
-                  if (!tripal_jbrowse_mgmt_copy_file($file_index[0], $path, $symbolic_link)) {
-                    form_set_error('file_path', 'Failed to copy file' . $file_gz[0] . ' to ' . $path.'. If this track is expected to create by existed file, please have Symbolic Link selected.');
-                  }
-                }
-              } catch (Exception $exception) {
-                form_set_error($exception->getMessage());
-              }
+    case 'bam':
+      $index = $_FILES['files']['tmp_name']['file2'];
+      $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
+      break;
 
-            }
-          }
-        }
-      }
-      elseif (empty($file) && !empty($index)) {
-        form_set_error('file', 'Please upload both a gz and an index file.');
-      }
-      elseif (!empty($file) && empty($index)) {
-        form_set_error('file2', 'Please upload both a gz and an index file.');
-      }
-      else {
-        $gz_uploaded = tripal_jbrowse_mgmt_upload_file('file');
-        if (!$gz_uploaded) {
-          form_set_error('file', 'Unable to upload file');
-        }
-        else {
-          $gz_uploaded = tripal_jbrowse_mgmt_move_file($gz_uploaded, $path);
-          if (!isset($gz_uploaded)) {
-            form_set_error('file', 'Failed to move gz file to ' . $path . '.');
-          }
-          else {
-            $form_state['values']['uploaded_gz'] = $gz_uploaded;
-          }
-        }
-
-        $index_uploaded = tripal_jbrowse_mgmt_upload_file('file2');
-        if (!$index_uploaded) {
-          form_set_error('file2', 'Unable to upload file');
-        }
-        else {
-          $index_uploaded = tripal_jbrowse_mgmt_move_file($index_uploaded, $path);
-          if (!isset($index_uploaded)) {
-            form_set_error('file2', 'Failed to move index file to ' . $path . '.');
-          }
-          else {
-            $form_state['values']['uploaded_tbi'] = $index_uploaded;
-          }
-        }
-      }
-
+    case 'carm':
+      $index = $_FILES['files']['tmp_name']['file2'];
+      $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
       break;
 
     default:
@@ -286,11 +221,11 @@ function tripal_jbrowse_mgmt_add_track_form_submit($form, &$form_state) {
   if (!empty($values['dir_path'])) {
     $file = $values['dir_path'];
   }
-  if (!empty($values['uploaded_gz'])) {
-    $file = $values['uploaded_gz'];
+  if (!empty($values['uploaded_file_index'])) {
+    $file = $values['uploaded_file_index'];
   }
-  if (!empty($values['uploaded_file'])) {
-    $file = $values['uploaded_file'];
+  if (!empty($values['uploaded_file_data'])) {
+    $file = $values['uploaded_file_data'];
   }
 
   $instance = tripal_jbrowse_mgmt_get_instance($values['instance_id']);

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -52,7 +52,7 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
   $form['data']['file_type'] = [
     '#type' => 'select',
     '#title' => t('File Type'),
-    '#options' => drupal_map_assoc(['gff', 'bed', 'gbk', 'vcf', 'bw']),
+    '#options' => drupal_map_assoc(['gff', 'bed', 'gbk', 'bam', 'cram', 'vcf', 'bw']),
     '#description' => t('See http://gmod.org/wiki/JBrowse_Configuration_Guide#flatfile-to-json.pl for more info.'),
     '#required' => TRUE,
   ];

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -143,13 +143,7 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
   }
   $base_path = $base_path . '/data';
 
-  if ($file_type === 'vcf') {
-    $path = $base_path . '/vcf';
-  }
-  if (($file_type === 'bam') OR ($file_type === 'cram')){
-    $path = $base_path . '/bam';
-  }
-  elseif ($file_type === 'bw') {
+  if ($file_type === 'bw') {
     $path = $base_path . '/wig';
   }
   else {
@@ -157,16 +151,19 @@ function tripal_jbrowse_mgmt_add_track_form_validate($form, &$form_state) {
   }
   switch ($file_type) {
     case 'vcf':
+      $path = $base_path . '/vcf';
       $index = $_FILES['files']['tmp_name']['file2'];
       $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
       break;
 
     case 'bam':
+      $path = $base_path . '/bam';
       $index = $_FILES['files']['tmp_name']['file2'];
       $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
       break;
 
     case 'cram':
+      $path = $base_path . '/bam';
       $index = $_FILES['files']['tmp_name']['file2'];
       $form_state = tripal_jbrowse_mgmt_validate_folder_upload($file, $index, $path, $form_state);
       break;

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_tracks.form.inc
@@ -105,6 +105,7 @@ function tripal_jbrowse_mgmt_add_track_form($form, &$form_state, $instance_id) {
   $form['data']['symbolic_link'] = [
     '#type' => 'checkbox',
     '#title' => t('Symbolic Link'),
+    '#default_value' => true,
     '#description' => t('Create a symbolic link rather than make a copy of the file. This only applies when a path on the server is supplied.<br>Please have Symbolic Link selected if the same file is used for new track.'),
   ];
 


### PR DESCRIPTION
- include alignment track in tripal_jbrowse

- add new Track Type: Alignment; new file types: bam, cram

- able upload of bam/cram fromat files with index in from Path to Directory

- move validation of bam/cram/vcf in Adding Track to a function

- already tested on local site and KP-dev site

How to test:
1. change to branch 46-alignments 
2. prepare file, like, one bam file and its index file in one folder
3. check if prepared bam/cram files upload already in `your_site/toos/jbrowse/data/your_species/data/bam`, delete if yes
4. go to `Home » Administration » Tripal » Extensions » Tripal JBrowse Management` to add this alignment track 
5. test if it can be displayed properly in JBrowse 
6. test if it is available in track list and can be managed (change category, edit json ...)
