### PR TITLE
Add permission to view excluded embedded pages.

### DIFF
--- a/tripal_jbrowse_page/tripal_jbrowse_page.module
+++ b/tripal_jbrowse_page/tripal_jbrowse_page.module
@@ -23,19 +23,22 @@ function tripal_jbrowse_page_menu() {
   $instances = tripal_jbrowse_mgmt_get_instances();
   foreach ($instances as $instance) {
 
-    if (tripal_jbrowse_page_is_instance_public($instance->id)) {
+    // Create the menu item.
+    $path = 'jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species;
+    $items[$path] = [
+      'title' => $instance->title,
+      'description' => $instance->description,
+      'page callback' => 'tripal_jbrowse_page_page',
+      'page arguments' => [1, 2],
+      'file' => 'includes/tripal_jbrowse_page.page.inc',
+      'type' => MENU_SUGGESTED_ITEM,
+    ];
 
-      // Create the menu item.
-      $path = 'jbrowse/'.$instance->organism->genus . '-' . $instance->organism->species;
-      $items[$path] = [
-        'title' => $instance->title,
-        'description' => $instance->description,
-        'page callback' => 'tripal_jbrowse_page_page',
-        'page arguments' => [1, 2],
-        'access arguments' => ['access content'],
-        'file' => 'includes/tripal_jbrowse_page.page.inc',
-        'type' => MENU_SUGGESTED_ITEM,
-      ];
+    if (tripal_jbrowse_page_is_instance_public($instance->id)) {
+      $items[$path]['access arguments'] = ['access content'];
+    }
+    else {
+      $items[$path]['access arguments'] = ['view private jbrowse page'];
     }
   }
 
@@ -73,6 +76,20 @@ function tripal_jbrowse_page_theme($existing, $type, $theme, $path) {
       'variables' => array('url' => ''),
     ),
   );
+
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function tripal_jbrowse_page_permissions() {
+  $items = [];
+
+  $items['view private jbrowse page'] = [
+    'title' => t('View excluded JBrowse pages'),
+    'description' => t('If users have this permission and know the link to the page, they will be able to see it. The instance will still not be included in the JBrowse instances list.'),
+  ];
 
   return $items;
 }

--- a/tripal_jbrowse_page/tripal_jbrowse_page.module
+++ b/tripal_jbrowse_page/tripal_jbrowse_page.module
@@ -83,7 +83,7 @@ function tripal_jbrowse_page_theme($existing, $type, $theme, $path) {
 /**
  * Implements hook_permission().
  */
-function tripal_jbrowse_page_permissions() {
+function tripal_jbrowse_page_permission() {
   $items = [];
 
   $items['view private jbrowse page'] = [


### PR DESCRIPTION
Before pages which were excluded from Tripal JBrowse page integration simply did not have an embedded page menu item. This PR creates a new permission to allow those pages to be seen by users with permission. Excluded instances are still not shown in the listing, regardless of permission.

Uses:
 - Allows you to have private JBrowse instances that still have your site branding
 - Can be used to allow a small group of users to approve or try out the JBrowse first.

Testing:
1. Check out this branch
2. Clear the menu cache
- Check that all non-excluded JBrowse pages are still accessible without permission.
- Check that excluded JBrowse pages are only accessible with permission. (embeded pages are `[your site]/jbrowse/[genus]-[species]/[instanceid]`)
- Check that excluded JBrowse pages are still not in the public listing.