### PR TITLE
Add support for gff3 file extension

### DIFF
--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt.api.inc
@@ -375,7 +375,7 @@ function tripal_jbrowse_mgmt_make_slug($string) {
  */
 function tripal_jbrowse_mgmt_upload_file($field) {
   $file = file_save_upload($field, [
-    'file_validate_extensions' => ['fasta faa fna fastq txt gff vcf wig gz tbi bw bam bai cram'],
+    'file_validate_extensions' => ['fasta faa fna fastq txt gff gff3 vcf wig gz tbi bw bam bai cram'],
     // Make it 20 GB max.
     'file_validate_size' => [1024 * 1024 * 1024 * 20],
   ]);


### PR DESCRIPTION
This is a very minor change to allow files with gff3 extension to be loaded.

```'file_validate_extensions' => ['fasta faa fna fastq txt gff vcf wig gz tbi bw bam bai cram'],```  
becomes  
```'file_validate_extensions' => ['fasta faa fna fastq txt gff gff3 vcf wig gz tbi bw bam bai cram'],```