### PR TITLE
Fixes issue #65

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -49,7 +49,7 @@ jobs:
         coverage: xdebug
         tools: composer, phpunit
 
-    # Install Drush/Drupal/Tripal
+    # Install Drush/Drupal/Tripal (uses the dev version of Tripal)
     - name: Setup Drush, Drupal 7.x, Tripal 3.x
       id: tripalsetup
       uses: tripal/setup-tripal-action@7.x-3.x-1.0
@@ -57,6 +57,7 @@ jobs:
         postgres_user: tripaladmin
         postgres_pass: somesupersecurepassword
         postgres_db: testdb
+        tripal_version: 7.x-3.x
 
     # Install Tripal Extension Module.
     - name: Install Tripal Extension Module

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_edit.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_edit.form.inc
@@ -77,7 +77,7 @@ function tripal_jbrowse_mgmt_edit_form_validate($form, &$form_state) {
   // Analysis user is wanting to add to this instance, test this against existing
   // instances and see if organism+this analysis matches any.
   $analysis_id = '';
-  if ($values['analysis']) {
+  if ($values['analysis'] && !$form['analysis']['#disabled']) {
     $analysis_id = tripal_jbrowse_mgmt_get_analysis_id_from_string($values['analysis']);
 
     preg_match_all('!\d+!', $values['analysis'], $match_analysis);
@@ -137,7 +137,7 @@ function tripal_jbrowse_mgmt_edit_form_submit($form, &$form_state) {
   $description = isset($values['description']) ? $values['description'] : '';
 
   $analysis_id = '';
-  if ($values['analysis']) {
+  if ($values['analysis'] && !$form['analysis']['#disabled']) {
     $analysis_id = tripal_jbrowse_mgmt_get_analysis_id_from_string($values['analysis']);
 
     preg_match_all('!\d+!', $values['analysis'], $match_analysis);

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_edit.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_edit.form.inc
@@ -30,6 +30,13 @@ function tripal_jbrowse_mgmt_edit_form($form, &$form_state) {
   // Set Default Values.
   $form['organism']['#default_value'] = $instance->organism_id;
   $form['description']['#default_value'] = $instance->description;
+
+  // Sequence Assembly field once set will keep the
+  // same value - field is disabled.
+  $analysis_name = ($instance->analysis_id) ? $instance->analysis->name : ''; 
+  $form['analysis']['#default_value'] = $analysis_name;
+  $form['analysis']['#disabled'] = TRUE;
+
   $form['page']['start-loc']['#default_value'] = tripal_jbrowse_mgmt_get_instance_property($instance_id, 'start-loc');
   $form['page']['start-tracks']['#default_value'] = tripal_jbrowse_mgmt_get_instance_property($instance_id, 'start-tracks');
 
@@ -54,11 +61,33 @@ function tripal_jbrowse_mgmt_edit_form_validate($form, &$form_state) {
 
   $instance_id = $form_state['build_info']['args'][0];
   $instances = tripal_jbrowse_mgmt_get_instances(['organism_id' => $organism]);
-  if (!empty($instances)) {
-    if ($instances[0]->id != $instance_id) {
+  
+  // Get the current instance.
+  $result = tripal_jbrowse_mgmt_get_instances(['id' => $instance_id]);
+  if (empty($result)) {
+    drupal_set_message('Unable to access the instance you would like to edit.', 'error');
+  }
+  else {
+    $current_instance = $result[0]; 
+  }
+  
+  // When saving modifications, validate organism and analysis
+  // to make sure that no instances share the same organism and analysis.
+  // When anaysis is not set, ensure the same for instances without analysis.
+  $current_instance_analysis_id = ($current_instance->analysis_id)
+    ? $current_instance->analysis_id : 0;
+  
+  foreach($instances as $instance) {
+    // Just see if there is other out there so exclude itself.
+    if ($instance->id == $instance_id) continue;
+
+    $instance_analysis_id = ($instance->analysis_id) ? $instance->analysis_id : 0;
+    if ($instance_analysis_id == $current_instance_analysis_id) {
+      // In the pools of instances (same organism), an instance was found
+      // matching the orgnism and analysis id (set or not set).
       form_set_error(
         'organism',
-        'A JBrowse instance for the selected organism already exists. You can edit the instance from the instances page.'
+        'A JBrowse instance with the same organism and sequence assembly already exits. Please select a different organism.'
       );
     }
   }

--- a/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_edit.form.inc
+++ b/tripal_jbrowse_mgmt/includes/tripal_jbrowse_mgmt_edit.form.inc
@@ -35,7 +35,9 @@ function tripal_jbrowse_mgmt_edit_form($form, &$form_state) {
   // same value - field is disabled.
   $analysis_name = ($instance->analysis_id) ? $instance->analysis->name : ''; 
   $form['analysis']['#default_value'] = $analysis_name;
-  $form['analysis']['#disabled'] = TRUE;
+  // Allow changes only when field has not been set a value (TRUE - disabled).
+  $enable_analysis = ($analysis_name) ? TRUE : FALSE;
+  $form['analysis']['#disabled'] = $enable_analysis;
 
   $form['page']['start-loc']['#default_value'] = tripal_jbrowse_mgmt_get_instance_property($instance_id, 'start-loc');
   $form['page']['start-tracks']['#default_value'] = tripal_jbrowse_mgmt_get_instance_property($instance_id, 'start-tracks');
@@ -71,12 +73,30 @@ function tripal_jbrowse_mgmt_edit_form_validate($form, &$form_state) {
     $current_instance = $result[0]; 
   }
   
+  // Allow user to provide analysis on edit only when it was not set in create form.
+  // Analysis user is wanting to add to this instance, test this against existing
+  // instances and see if organism+this analysis matches any.
+  $analysis_id = '';
+  if ($values['analysis']) {
+    $analysis_id = tripal_jbrowse_mgmt_get_analysis_id_from_string($values['analysis']);
+
+    preg_match_all('!\d+!', $values['analysis'], $match_analysis);
+    $analysis_id = array_pop($match_analysis[0]);
+  }
+
   // When saving modifications, validate organism and analysis
   // to make sure that no instances share the same organism and analysis.
   // When anaysis is not set, ensure the same for instances without analysis.
-  $current_instance_analysis_id = ($current_instance->analysis_id)
-    ? $current_instance->analysis_id : 0;
-  
+  if ($current_instance->analysis_id) {
+    // Use analysis on record for this instance.
+    $current_instance_analysis_id = $current_instance->analysis_id;
+  }
+  else {
+    // Othwerwise, check analysis field and use it or set to 0 when
+    // neither on record nor field is available.
+    $current_instance_analysis_id = ($analysis_id) ? $analysis_id : 0;
+  }
+    
   foreach($instances as $instance) {
     // Just see if there is other out there so exclude itself.
     if ($instance->id == $instance_id) continue;
@@ -116,6 +136,14 @@ function tripal_jbrowse_mgmt_edit_form_submit($form, &$form_state) {
   $organism_id = $values['organism'];
   $description = isset($values['description']) ? $values['description'] : '';
 
+  $analysis_id = '';
+  if ($values['analysis']) {
+    $analysis_id = tripal_jbrowse_mgmt_get_analysis_id_from_string($values['analysis']);
+
+    preg_match_all('!\d+!', $values['analysis'], $match_analysis);
+    $analysis_id = array_pop($match_analysis[0]);
+  }
+
   // Check if this is an add or edit form.
   $edit_form = FALSE;
   if (isset($form_state['build_info']['args'][0]) AND is_numeric($form_state['build_info']['args'][0])) {
@@ -136,6 +164,10 @@ function tripal_jbrowse_mgmt_edit_form_submit($form, &$form_state) {
     'title' => $title,
     'description' => $description,
   ];
+
+  if ($analysis_id) {
+    $data['analysis_id'] = $analysis_id;
+  }
   $success = tripal_jbrowse_mgmt_update_instance($instance_id, $data);
 
   if ($success) {


### PR DESCRIPTION
This PR fixes Issue #65 - Unable to modify instance.

The error is caused by hook_validate when modifying an instance where there is another instance and both share the same organism. This fix takes into account sequence assembly information before checking for identical instance.

To test:
// No two instances share same organism and empty sequence assembly 
1. Create an instance and set organism to X and sequence assembly field to empty.
2. Create a similar instance to step 1, except set organism different to X so that when you modify this (step 2 instance) and set organism to match X (step 1 instance) it should trigger the validation.  

// No two instances share same organism and same sequence assembly
1. Find an instance and note organism and sequence assembly.
2. Create a new instance, set the organism other than the organism in step 1 (as noted) and sequence assembly to be the same in step 1.
3. Modify instance in step 2 and change the organism to match the organism in step 1. This should trigger the validation, an existing instance matched the organism and sequence assembly information.

Knowing what triggers validation, test fields organism, description, start location and tracks to display as well.